### PR TITLE
Android: compute + send the app-lib hash (makes the server baseline gate reachable)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,56 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    # Repo secrets are not available to PRs from forks; skip them.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request as a senior Flutter plugin engineer.
+
+            Classify every finding by severity and lead each one with its
+            label:
+            - **Critical** — bugs, broken behavior, data loss, security
+              flaws. Only Critical findings block merging.
+            - **Medium** — real but non-blocking improvements; the team may
+              table these as tracked follow-ups.
+            - **Low** — style, polish, minor hardening.
+
+            Before raising a finding, read the PR's existing comments and
+            review threads (`gh pr view <n> --comments`). Do not re-raise a
+            finding the author has already refuted or explicitly tabled
+            there unless you have new evidence. When claiming a control-flow
+            gap (e.g. a missing try/finally), read the entire enclosing
+            function first and cite the line numbers that demonstrate it.
+
+            Focus on correctness bugs and edge cases, API misuse,
+            error-handling gaps, security issues, and backwards
+            compatibility for existing users. Skip pure style nits.
+
+            Use `gh pr comment` for the summary and
+            `mcp__github_inline_comment__create_inline_comment` (with
+            confirmed: true) for line-specific issues. Only post GitHub
+            comments — do not submit review text as plain messages.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,42 @@
+group 'com.flutterplaza.flutterplaza_code_push'
+version '1.0'
+
+buildscript {
+    ext.kotlin_version = '1.8.22'
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    namespace 'com.flutterplaza.flutterplaza_code_push'
+    compileSdk 34
+
+    defaultConfig {
+        minSdk 21
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/android/src/main/kotlin/com/flutterplaza/flutterplaza_code_push/FlutterplazaCodePushPlugin.kt
+++ b/android/src/main/kotlin/com/flutterplaza/flutterplaza_code_push/FlutterplazaCodePushPlugin.kt
@@ -15,13 +15,19 @@ class FlutterplazaCodePushPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
   private lateinit var channel: MethodChannel
   private lateinit var context: Context
 
+  /** False after detach; late async replies are dropped instead of hitting
+   * a torn-down messenger (hot-restart / engine-destroy race). */
+  @Volatile private var attached = false
+
   override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     context = binding.applicationContext
     channel = MethodChannel(binding.binaryMessenger, "flutterplaza_code_push")
     channel.setMethodCallHandler(this)
+    attached = true
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    attached = false
     channel.setMethodCallHandler(null)
   }
 
@@ -32,7 +38,15 @@ class FlutterplazaCodePushPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
         val handler = Handler(Looper.getMainLooper())
         Thread {
           val hash = runCatching { computeAppLibHash() }.getOrNull()
-          handler.post { result.success(hash) }
+          handler.post {
+            if (!attached) return@post
+            try {
+              result.success(hash)
+            } catch (_: Exception) {
+              // Messenger torn down between the check and the reply; the
+              // Dart side times out and falls back on its own.
+            }
+          }
         }.start()
       }
       else -> result.notImplemented()
@@ -40,34 +54,48 @@ class FlutterplazaCodePushPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
   }
 
   /**
-   * Streams SHA-256 over lib/<abi>/libapp.so as packaged in the installed
-   * APK (or the matching split), returning lowercase hex, or null if it
-   * can't be located. Reads the archived bytes directly so the digest is
-   * stable regardless of whether native libs are extracted on install.
+   * SHA-256 (lowercase hex) of lib/<abi>/libapp.so as packaged in the
+   * installed APK or its splits, or null if it can't be located. Reads the
+   * archived bytes directly so the digest is stable regardless of whether
+   * native libs are extracted on install.
+   *
+   * ABIs are tried in [Build.SUPPORTED_ABIS] order — the same preference
+   * order the system uses when it picks which packaged ABI to run — so the
+   * entry hashed is the one the process actually loaded (e.g. a 32-bit-only
+   * APK on a 64-bit device hashes the armeabi-v7a entry, not a nonexistent
+   * arm64 one). Each archive is tried independently: one unreadable APK
+   * doesn't abort the scan of the rest.
    */
   private fun computeAppLibHash(): String? {
-    val abi = Build.SUPPORTED_ABIS.firstOrNull() ?: return null
-    val entryName = "lib/$abi/libapp.so"
     val info = context.applicationInfo
     val apks = buildList {
       info.sourceDir?.let { add(it) }
       info.splitSourceDirs?.let { addAll(it) }
     }
-    for (apk in apks) {
-      ZipFile(apk).use { zip ->
-        val entry = zip.getEntry(entryName) ?: return@use
-        val digest = MessageDigest.getInstance("SHA-256")
-        zip.getInputStream(entry).use { input ->
-          val buf = ByteArray(64 * 1024)
-          while (true) {
-            val n = input.read(buf)
-            if (n < 0) break
-            digest.update(buf, 0, n)
-          }
-        }
-        return digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+    for (abi in Build.SUPPORTED_ABIS) {
+      val entryName = "lib/$abi/libapp.so"
+      for (apk in apks) {
+        val hash = runCatching { hashZipEntry(apk, entryName) }.getOrNull()
+        if (hash != null) return hash
       }
     }
     return null
+  }
+
+  /** Streams SHA-256 over [entryName] inside [apkPath]; null if absent. */
+  private fun hashZipEntry(apkPath: String, entryName: String): String? {
+    ZipFile(apkPath).use { zip ->
+      val entry = zip.getEntry(entryName) ?: return null
+      val digest = MessageDigest.getInstance("SHA-256")
+      zip.getInputStream(entry).use { input ->
+        val buf = ByteArray(64 * 1024)
+        while (true) {
+          val n = input.read(buf)
+          if (n < 0) break
+          digest.update(buf, 0, n)
+        }
+      }
+      return digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+    }
   }
 }

--- a/android/src/main/kotlin/com/flutterplaza/flutterplaza_code_push/FlutterplazaCodePushPlugin.kt
+++ b/android/src/main/kotlin/com/flutterplaza/flutterplaza_code_push/FlutterplazaCodePushPlugin.kt
@@ -1,0 +1,73 @@
+package com.flutterplaza.flutterplaza_code_push
+
+import android.content.Context
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.security.MessageDigest
+import java.util.zip.ZipFile
+
+/** SHA-256 of the packaged native library for the running ABI. */
+class FlutterplazaCodePushPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
+  private lateinit var channel: MethodChannel
+  private lateinit var context: Context
+
+  override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    context = binding.applicationContext
+    channel = MethodChannel(binding.binaryMessenger, "flutterplaza_code_push")
+    channel.setMethodCallHandler(this)
+  }
+
+  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    channel.setMethodCallHandler(null)
+  }
+
+  override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+    when (call.method) {
+      "getAppLibHash" -> {
+        // Hash off the platform thread; deliver the result back on it.
+        val handler = Handler(Looper.getMainLooper())
+        Thread {
+          val hash = runCatching { computeAppLibHash() }.getOrNull()
+          handler.post { result.success(hash) }
+        }.start()
+      }
+      else -> result.notImplemented()
+    }
+  }
+
+  /**
+   * Streams SHA-256 over lib/<abi>/libapp.so as packaged in the installed
+   * APK (or the matching split), returning lowercase hex, or null if it
+   * can't be located. Reads the archived bytes directly so the digest is
+   * stable regardless of whether native libs are extracted on install.
+   */
+  private fun computeAppLibHash(): String? {
+    val abi = Build.SUPPORTED_ABIS.firstOrNull() ?: return null
+    val entryName = "lib/$abi/libapp.so"
+    val info = context.applicationInfo
+    val apks = buildList {
+      info.sourceDir?.let { add(it) }
+      info.splitSourceDirs?.let { addAll(it) }
+    }
+    for (apk in apks) {
+      ZipFile(apk).use { zip ->
+        val entry = zip.getEntry(entryName) ?: return@use
+        val digest = MessageDigest.getInstance("SHA-256")
+        zip.getInputStream(entry).use { input ->
+          val buf = ByteArray(64 * 1024)
+          while (true) {
+            val n = input.read(buf)
+            if (n < 0) break
+            digest.update(buf, 0, n)
+          }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+      }
+    }
+    return null
+  }
+}

--- a/android/src/main/kotlin/com/flutterplaza/flutterplaza_code_push/FlutterplazaCodePushPlugin.kt
+++ b/android/src/main/kotlin/com/flutterplaza/flutterplaza_code_push/FlutterplazaCodePushPlugin.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -65,8 +66,14 @@ class FlutterplazaCodePushPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
    * APK on a 64-bit device hashes the armeabi-v7a entry, not a nonexistent
    * arm64 one). Each archive is tried independently: one unreadable APK
    * doesn't abort the scan of the rest.
+   *
+   * Work is bounded: the read loop stops early once the plugin detaches
+   * or [HASH_BUDGET_MS] elapses (the Dart caller has given up by then),
+   * so an abandoned request can't keep streaming a large APK on slow
+   * storage indefinitely.
    */
   private fun computeAppLibHash(): String? {
+    val deadline = SystemClock.elapsedRealtime() + HASH_BUDGET_MS
     val info = context.applicationInfo
     val apks = buildList {
       info.sourceDir?.let { add(it) }
@@ -75,21 +82,23 @@ class FlutterplazaCodePushPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
     for (abi in Build.SUPPORTED_ABIS) {
       val entryName = "lib/$abi/libapp.so"
       for (apk in apks) {
-        val hash = runCatching { hashZipEntry(apk, entryName) }.getOrNull()
+        val hash = runCatching { hashZipEntry(apk, entryName, deadline) }.getOrNull()
         if (hash != null) return hash
       }
     }
     return null
   }
 
-  /** Streams SHA-256 over [entryName] inside [apkPath]; null if absent. */
-  private fun hashZipEntry(apkPath: String, entryName: String): String? {
+  /** Streams SHA-256 over [entryName] inside [apkPath]; null if absent,
+   * or if the plugin detaches / [deadline] passes mid-read. */
+  private fun hashZipEntry(apkPath: String, entryName: String, deadline: Long): String? {
     ZipFile(apkPath).use { zip ->
       val entry = zip.getEntry(entryName) ?: return null
       val digest = MessageDigest.getInstance("SHA-256")
       zip.getInputStream(entry).use { input ->
         val buf = ByteArray(64 * 1024)
         while (true) {
+          if (!attached || SystemClock.elapsedRealtime() > deadline) return null
           val n = input.read(buf)
           if (n < 0) break
           digest.update(buf, 0, n)
@@ -97,5 +106,11 @@ class FlutterplazaCodePushPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
       }
       return digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xFF) }
     }
+  }
+
+  private companion object {
+    /** Slightly past the Dart caller's 10 s timeout: once this elapses
+     * the reply can no longer be used, so the stream is abandoned. */
+    const val HASH_BUDGET_MS = 12_000L
   }
 }

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -336,7 +336,14 @@ abstract final class CodePush {
       if (expectedBaselineHash != null) {
         final actualBaselineHash = await _computeBaselineHash();
         if (actualBaselineHash != null &&
-            actualBaselineHash != expectedBaselineHash) {
+            actualBaselineHash != expectedBaselineHash &&
+            // Report each distinct mismatch pair once per session —
+            // checkAndInstall runs on a periodic timer, and a stable
+            // mismatch (e.g. an ABI whose hash the server doesn't have)
+            // would otherwise POST identical telemetry on every tick.
+            _reportedBaselineMismatches.add(
+              '$expectedBaselineHash|$actualBaselineHash',
+            )) {
           await _reportIncompatibleBaseline(
             serverUrl: serverUrl,
             appId: appId,
@@ -690,12 +697,18 @@ abstract final class CodePush {
   @visibleForTesting
   static bool debugForceAndroidPlatform = false;
 
+  /// Baseline-hash mismatch pairs (`expected|actual`) already reported to
+  /// the server this session, so periodic checks don't repeat identical
+  /// telemetry every poll cycle.
+  static final Set<String> _reportedBaselineMismatches = <String>{};
+
   /// Test-only: clears the baseline-hash session state between tests.
   @visibleForTesting
   static void debugResetBaselineHashCache() {
     _cachedBaselineHash = null;
     _baselineHashFailedAt = null;
     _baselineHashInFlight = null;
+    _reportedBaselineMismatches.clear();
   }
 
   /// Cached distribution-proof baseline UUID (see [_readBaselineId]).

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -621,11 +621,10 @@ abstract final class CodePush {
   /// to load a patch whose recorded baseline hash disagrees with
   /// this value.
   ///
-  /// Cached in memory after first computation. Reading the few-MB
-  /// AOT blob and hashing it takes ~20–50 ms on a modern device —
-  /// once per session is fine. Non-iOS is a no-op for now (the
-  /// Android engine loads patches differently and the crash path
-  /// the hash guards against is iOS-specific).
+  /// Cached in memory after first computation. Hashing the few-MB
+  /// AOT blob takes ~20–50 ms on a modern device — once per session
+  /// is fine. On iOS the blob is read from the app bundle; on Android
+  /// it is read from the platform side.
   static String? _cachedBaselineId;
 
   /// Read the distribution-proof baseline UUID from Info.plist
@@ -651,6 +650,18 @@ abstract final class CodePush {
   static Future<String?> _computeBaselineHash() async {
     if (_cachedBaselineHash != null) return _cachedBaselineHash;
     try {
+      if (Platform.isAndroid) {
+        // Android packages the AOT snapshot as lib/<abi>/libapp.so inside
+        // the APK; the platform side reads and hashes it.
+        final hash = await _pluginChannel
+            .invokeMethod<String>('getAppLibHash')
+            .timeout(const Duration(seconds: 3));
+        if (hash != null && hash.isNotEmpty) {
+          _cachedBaselineHash = hash;
+          return hash;
+        }
+        return null;
+      }
       if (!Platform.isIOS) return null;
 
       // On iOS, Platform.resolvedExecutable points at

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -335,16 +335,17 @@ abstract final class CodePush {
       final expectedBaselineHash = data['baseline_hash'] as String?;
       if (expectedBaselineHash != null) {
         final actualBaselineHash = await _computeBaselineHash();
+        // Report each distinct mismatch pair once per session —
+        // checkAndInstall runs on a periodic timer, and a stable
+        // mismatch (e.g. an ABI whose hash the server doesn't have)
+        // would otherwise POST identical telemetry on every tick. The
+        // pair is recorded only after the server acknowledges the
+        // report, so a transient telemetry failure retries next cycle.
+        final mismatchKey = '$expectedBaselineHash|$actualBaselineHash';
         if (actualBaselineHash != null &&
             actualBaselineHash != expectedBaselineHash &&
-            // Report each distinct mismatch pair once per session —
-            // checkAndInstall runs on a periodic timer, and a stable
-            // mismatch (e.g. an ABI whose hash the server doesn't have)
-            // would otherwise POST identical telemetry on every tick.
-            _reportedBaselineMismatches.add(
-              '$expectedBaselineHash|$actualBaselineHash',
-            )) {
-          await _reportIncompatibleBaseline(
+            !_reportedBaselineMismatches.contains(mismatchKey)) {
+          final reported = await _reportIncompatibleBaseline(
             serverUrl: serverUrl,
             appId: appId,
             patchId: patchId,
@@ -353,6 +354,9 @@ abstract final class CodePush {
             expectedFingerprint: expectedBaselineHash,
             actualFingerprint: actualBaselineHash,
           );
+          if (reported) {
+            _reportedBaselineMismatches.add(mismatchKey);
+          }
         }
       }
 
@@ -575,8 +579,10 @@ abstract final class CodePush {
   /// Best-effort telemetry POST to let the server know a device was
   /// stranded on an incompatible baseline. Swallows every error so
   /// telemetry failure can never cascade into an app crash — this is
-  /// already the unhappy path.
-  static Future<void> _reportIncompatibleBaseline({
+  /// already the unhappy path. Returns true only when the server
+  /// acknowledged the report (2xx), so callers can decide whether to
+  /// retry later.
+  static Future<bool> _reportIncompatibleBaseline({
     required String serverUrl,
     required String appId,
     required String? patchId,
@@ -601,14 +607,21 @@ abstract final class CodePush {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
         final req =
             await client.postUrl(uri).timeout(const Duration(seconds: 5));
-        req.headers.set('Content-Type', 'application/json');
-        req.write(jsonEncode(payload));
-        await req.close().timeout(const Duration(seconds: 5));
+        req.headers.set('Content-Type', 'application/json; charset=utf-8');
+        // Send encoded bytes, not a string: HttpClientRequest.write()
+        // defaults to Latin-1, which throws on any non-Latin-1 character
+        // in the payload (e.g. an em dash in a reason string) and would
+        // silently drop the report.
+        req.add(utf8.encode(jsonEncode(payload)));
+        final res = await req.close().timeout(const Duration(seconds: 5));
+        await res.drain<void>();
+        return res.statusCode >= 200 && res.statusCode < 300;
       } finally {
         client.close(force: true);
       }
     } catch (_) {
       // Telemetry is best-effort. Never crash over it.
+      return false;
     }
   }
 

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -339,8 +339,10 @@ abstract final class CodePush {
         // checkAndInstall runs on a periodic timer, and a stable
         // mismatch (e.g. an ABI whose hash the server doesn't have)
         // would otherwise POST identical telemetry on every tick. The
-        // pair is recorded only after the server acknowledges the
-        // report, so a transient telemetry failure retries next cycle.
+        // pair is recorded once the report completes an HTTP round
+        // trip, whatever the status: a persistently failing endpoint
+        // must not turn every mismatching device into a per-poll
+        // beacon. Only a transport failure (offline, timeout) retries.
         final mismatchKey = '$expectedBaselineHash|$actualBaselineHash';
         if (actualBaselineHash != null &&
             actualBaselineHash != expectedBaselineHash &&
@@ -579,9 +581,10 @@ abstract final class CodePush {
   /// Best-effort telemetry POST to let the server know a device was
   /// stranded on an incompatible baseline. Swallows every error so
   /// telemetry failure can never cascade into an app crash — this is
-  /// already the unhappy path. Returns true only when the server
-  /// acknowledged the report (2xx), so callers can decide whether to
-  /// retry later.
+  /// already the unhappy path. Returns true when the request completed
+  /// an HTTP round trip (any status — the report was delivered even if
+  /// the server refused it); false only on transport failure, so
+  /// callers can retry when the device was offline.
   static Future<bool> _reportIncompatibleBaseline({
     required String serverUrl,
     required String appId,
@@ -615,7 +618,7 @@ abstract final class CodePush {
         req.add(utf8.encode(jsonEncode(payload)));
         final res = await req.close().timeout(const Duration(seconds: 5));
         await res.drain<void>();
-        return res.statusCode >= 200 && res.statusCode < 300;
+        return true;
       } finally {
         client.close(force: true);
       }
@@ -667,8 +670,11 @@ abstract final class CodePush {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
         final req =
             await client.postUrl(uri).timeout(const Duration(seconds: 5));
-        req.headers.set('Content-Type', 'application/json');
-        req.write(jsonEncode(payload));
+        req.headers.set('Content-Type', 'application/json; charset=utf-8');
+        // Encoded bytes, not a string: write() defaults to Latin-1 and
+        // throws on any non-Latin-1 character in the native-written
+        // reason, which would silently strand the marker forever.
+        req.add(utf8.encode(jsonEncode(payload)));
         final res = await req.close().timeout(const Duration(seconds: 5));
         if (res.statusCode >= 200 && res.statusCode < 300) {
           try {

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -206,8 +206,7 @@ abstract final class CodePush {
       // (further down) still protects us.
       final deviceBaselineHash = await _computeBaselineHash();
       final deviceBaselineId = await _readBaselineId();
-      final url =
-          '$serverUrl/api/v1/updates'
+      final url = '$serverUrl/api/v1/updates'
           '?app_id=$appId'
           '&version=${Uri.encodeComponent(releaseVersion)}'
           '&platform=$_platform'
@@ -250,8 +249,7 @@ abstract final class CodePush {
               final serverPatchId = patchId;
               final serverPatchHash = data['patch_hash']?.toString();
               final idMatch = rbId != null && rbId == serverPatchId;
-              final hashMatch =
-                  rbHash != null &&
+              final hashMatch = rbHash != null &&
                   serverPatchHash != null &&
                   rbHash == serverPatchHash;
               print(
@@ -297,8 +295,7 @@ abstract final class CodePush {
           serverUrl: serverUrl,
           appId: appId,
           patchId: patchId,
-          reason:
-              'Engine has no code push support (stock Flutter engine '
+          reason: 'Engine has no code push support (stock Flutter engine '
               'or missing flutter/codepush method channel).',
           expectedFingerprint: expectedEngineFingerprint,
           actualFingerprint: null,
@@ -313,8 +310,7 @@ abstract final class CodePush {
       if (expectedEngineFingerprint != null &&
           actualEngineFingerprint != 'unknown' &&
           expectedEngineFingerprint != actualEngineFingerprint) {
-        status.value =
-            'Incompatible baseline: engine ABI mismatch '
+        status.value = 'Incompatible baseline: engine ABI mismatch '
             '($actualEngineFingerprint vs $expectedEngineFingerprint)';
         await _reportIncompatibleBaseline(
           serverUrl: serverUrl,
@@ -345,8 +341,7 @@ abstract final class CodePush {
             serverUrl: serverUrl,
             appId: appId,
             patchId: patchId,
-            reason:
-                'Baseline hash mismatch (soft gate — proceeding '
+            reason: 'Baseline hash mismatch (soft gate — proceeding '
                 'with download; engine ABI check is the hard gate)',
             expectedFingerprint: expectedBaselineHash,
             actualFingerprint: actualBaselineHash,
@@ -424,8 +419,7 @@ abstract final class CodePush {
                 'HEADER_MISMATCH patchId=$patchId payload=${payload.length}',
               );
             }
-            status.value =
-                'Patch format is unexpected — rolling back. '
+            status.value = 'Patch format is unexpected — rolling back. '
                 'Upgrade flutter_compile to the latest version and '
                 'rebuild the patch.';
             await _iosImmediateRollback(
@@ -598,9 +592,8 @@ abstract final class CodePush {
       final client = HttpClient();
       try {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
-        final req = await client
-            .postUrl(uri)
-            .timeout(const Duration(seconds: 5));
+        final req =
+            await client.postUrl(uri).timeout(const Duration(seconds: 5));
         req.headers.set('Content-Type', 'application/json');
         req.write(jsonEncode(payload));
         await req.close().timeout(const Duration(seconds: 5));
@@ -652,9 +645,8 @@ abstract final class CodePush {
       final client = HttpClient();
       try {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
-        final req = await client
-            .postUrl(uri)
-            .timeout(const Duration(seconds: 5));
+        final req =
+            await client.postUrl(uri).timeout(const Duration(seconds: 5));
         req.headers.set('Content-Type', 'application/json');
         req.write(jsonEncode(payload));
         final res = await req.close().timeout(const Duration(seconds: 5));
@@ -676,6 +668,35 @@ abstract final class CodePush {
   /// session, since the AOT snapshot can't change while the app is
   /// running.
   static String? _cachedBaselineHash;
+
+  /// When the last hash computation failed (null result), the failure is
+  /// remembered here so one check cycle doesn't pay the platform-channel
+  /// timeout twice — [checkAndInstall] computes the hash at both the query
+  /// step and the soft-gate step. Retried after [_baselineHashRetryAfter]:
+  /// a transient first-boot failure (slow storage, cold cache) must not
+  /// disable the baseline gate for the whole session.
+  static DateTime? _baselineHashFailedAt;
+
+  /// How long a failed hash computation short-circuits before retrying.
+  static const Duration _baselineHashRetryAfter = Duration(minutes: 1);
+
+  /// In-flight hash computation, shared so concurrent callers don't stack
+  /// duplicate platform-channel invocations (and duplicate native hashing
+  /// threads) while one is already running.
+  static Future<String?>? _baselineHashInFlight;
+
+  /// Test-only: forces the Android branch of the baseline-hash path in
+  /// host unit tests, where `Platform.isAndroid` is always false.
+  @visibleForTesting
+  static bool debugForceAndroidPlatform = false;
+
+  /// Test-only: clears the baseline-hash session state between tests.
+  @visibleForTesting
+  static void debugResetBaselineHashCache() {
+    _cachedBaselineHash = null;
+    _baselineHashFailedAt = null;
+    _baselineHashInFlight = null;
+  }
 
   /// Cached distribution-proof baseline UUID (see [_readBaselineId]).
   static String? _cachedBaselineId;
@@ -718,10 +739,30 @@ abstract final class CodePush {
   /// AOT blob takes ~20–50 ms on a modern device — once per session
   /// is fine. On iOS the blob is read from the app bundle; on Android
   /// it is read from the platform side.
-  static Future<String?> _computeBaselineHash() async {
-    if (_cachedBaselineHash != null) return _cachedBaselineHash;
+  ///
+  /// Failures are memoized briefly (see [_baselineHashFailedAt]) and
+  /// concurrent callers share one in-flight computation, so a device that
+  /// can't produce a hash pays the platform-channel timeout at most once
+  /// per retry window instead of on every call.
+  static Future<String?> _computeBaselineHash() {
+    if (_cachedBaselineHash != null) {
+      return Future.value(_cachedBaselineHash);
+    }
+    final failedAt = _baselineHashFailedAt;
+    if (failedAt != null &&
+        DateTime.now().difference(failedAt) < _baselineHashRetryAfter) {
+      return Future.value(null);
+    }
+    return _baselineHashInFlight ??=
+        _computeBaselineHashUncached().then((hash) {
+      if (hash == null) _baselineHashFailedAt = DateTime.now();
+      return hash;
+    }).whenComplete(() => _baselineHashInFlight = null);
+  }
+
+  static Future<String?> _computeBaselineHashUncached() async {
     try {
-      if (Platform.isAndroid) {
+      if (debugForceAndroidPlatform || Platform.isAndroid) {
         // Android packages the AOT snapshot as lib/<abi>/libapp.so inside
         // the APK; the platform side reads and hashes it. Generous timeout:
         // a first-boot hash of a multi-MB entry on slow storage with a cold
@@ -1236,8 +1277,7 @@ class CodePushOverlay extends StatefulWidget {
     BuildContext context,
     VoidCallback onRestart,
     VoidCallback onDismiss,
-  )?
-  bannerBuilder;
+  )? bannerBuilder;
 
   /// Whether to show the debug status bar at the top. Defaults to false.
   final bool showDebugBar;
@@ -1436,7 +1476,7 @@ class CodePushPatchBuilder extends StatelessWidget {
 
   /// Builder called with the patch data string (or null if no patch).
   final Widget Function(BuildContext context, String? patchData, Widget? child)
-  builder;
+      builder;
 
   /// Optional child widget passed to the builder (typically the default/baseline UI).
   final Widget? child;

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -677,24 +677,7 @@ abstract final class CodePush {
   /// running.
   static String? _cachedBaselineHash;
 
-  /// Returns the SHA-256 hex of the currently-running baseline's
-  /// `App.framework/App` (iOS) or `libapp.so` (Android).
-  ///
-  /// This is the authoritative identity of the Dart code that's
-  /// loaded into the VM — bumping any Dart package (including this
-  /// one) changes the AOT class layout and produces a different
-  /// hash. We use it as the compatibility key for patches:
-  /// if `sha256(running baseline) != sha256(baseline the patch was
-  /// built against)`, the patch's class offsets are wrong and
-  /// `ui.codePushLoadModule` will abort the VM on the first class
-  /// allocation. The check at the top of [checkAndInstall] refuses
-  /// to load a patch whose recorded baseline hash disagrees with
-  /// this value.
-  ///
-  /// Cached in memory after first computation. Hashing the few-MB
-  /// AOT blob takes ~20–50 ms on a modern device — once per session
-  /// is fine. On iOS the blob is read from the app bundle; on Android
-  /// it is read from the platform side.
+  /// Cached distribution-proof baseline UUID (see [_readBaselineId]).
   static String? _cachedBaselineId;
 
   /// Read the distribution-proof baseline UUID from Info.plist
@@ -717,15 +700,35 @@ abstract final class CodePush {
     }
   }
 
+  /// Returns the SHA-256 hex of the currently-running baseline's
+  /// `App.framework/App` (iOS) or `libapp.so` (Android).
+  ///
+  /// This is the authoritative identity of the Dart code that's
+  /// loaded into the VM — bumping any Dart package (including this
+  /// one) changes the AOT class layout and produces a different
+  /// hash. We use it as the compatibility key for patches:
+  /// if `sha256(running baseline) != sha256(baseline the patch was
+  /// built against)`, the patch's class offsets are wrong and
+  /// `ui.codePushLoadModule` will abort the VM on the first class
+  /// allocation. The check at the top of [checkAndInstall] refuses
+  /// to load a patch whose recorded baseline hash disagrees with
+  /// this value.
+  ///
+  /// Cached in memory after first computation. Hashing the few-MB
+  /// AOT blob takes ~20–50 ms on a modern device — once per session
+  /// is fine. On iOS the blob is read from the app bundle; on Android
+  /// it is read from the platform side.
   static Future<String?> _computeBaselineHash() async {
     if (_cachedBaselineHash != null) return _cachedBaselineHash;
     try {
       if (Platform.isAndroid) {
         // Android packages the AOT snapshot as lib/<abi>/libapp.so inside
-        // the APK; the platform side reads and hashes it.
+        // the APK; the platform side reads and hashes it. Generous timeout:
+        // a first-boot hash of a multi-MB entry on slow storage with a cold
+        // page cache can take several seconds.
         final hash = await _pluginChannel
             .invokeMethod<String>('getAppLibHash')
-            .timeout(const Duration(seconds: 3));
+            .timeout(const Duration(seconds: 10));
         if (hash != null && hash.isNotEmpty) {
           _cachedBaselineHash = hash;
           return hash;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,5 +27,8 @@ dev_dependencies:
 flutter:
   plugin:
     platforms:
+      android:
+        package: com.flutterplaza.flutterplaza_code_push
+        pluginClass: FlutterplazaCodePushPlugin
       ios:
         pluginClass: FlutterplazaCodePushPlugin

--- a/test/baseline_hash_android_test.dart
+++ b/test/baseline_hash_android_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterplaza_code_push/flutterplaza_code_push.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  // The test binding installs an HttpClient stub that answers every
+  // request with a 400 and never touches the network. These tests need
+  // the real loopback stack to reach the local capture server.
+  HttpOverrides.global = null;
+
+  const pluginChannel = MethodChannel('flutterplaza_code_push');
+  const fakeHash =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  late HttpServer server;
+  late List<Uri> requests;
+  late int hashCalls;
+
+  void mockAppLibHash(String? hash) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pluginChannel, (MethodCall call) async {
+      if (call.method == 'getAppLibHash') {
+        hashCalls++;
+        return hash;
+      }
+      return null;
+    });
+  }
+
+  Future<void> check() => CodePush.checkAndInstall(
+        serverUrl: 'http://127.0.0.1:${server.port}',
+        appId: 'test-app',
+        releaseVersion: '1.0.0+1',
+      );
+
+  setUp(() async {
+    hashCalls = 0;
+    requests = <Uri>[];
+    CodePush.debugForceAndroidPlatform = true;
+    CodePush.debugResetBaselineHashCache();
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((HttpRequest req) {
+      requests.add(req.uri);
+      req.response.statusCode = HttpStatus.noContent;
+      req.response.close();
+    });
+  });
+
+  tearDown(() async {
+    CodePush.debugForceAndroidPlatform = false;
+    CodePush.debugResetBaselineHashCache();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pluginChannel, null);
+    await server.close(force: true);
+  });
+
+  group('Android baseline hash on /updates', () {
+    test('sends baseline_hash when the platform side resolves a hash',
+        () async {
+      mockAppLibHash(fakeHash);
+
+      await check();
+
+      expect(requests, hasLength(1));
+      expect(requests.single.queryParameters['baseline_hash'], fakeHash);
+    });
+
+    test('omits baseline_hash when the platform side returns null', () async {
+      mockAppLibHash(null);
+
+      await check();
+
+      expect(requests, hasLength(1));
+      expect(
+        requests.single.queryParameters.containsKey('baseline_hash'),
+        isFalse,
+      );
+    });
+
+    test(
+        'caches a successful hash: platform channel invoked once across '
+        'checks', () async {
+      mockAppLibHash(fakeHash);
+
+      await check();
+      await check();
+
+      expect(hashCalls, 1);
+      expect(requests, hasLength(2));
+      expect(requests.last.queryParameters['baseline_hash'], fakeHash);
+    });
+
+    test(
+        'remembers a failure briefly: platform channel not re-invoked '
+        'within the retry window', () async {
+      mockAppLibHash(null);
+
+      await check();
+      await check();
+
+      expect(hashCalls, 1);
+      expect(requests, hasLength(2));
+      expect(
+        requests.last.queryParameters.containsKey('baseline_hash'),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/baseline_hash_android_test.dart
+++ b/test/baseline_hash_android_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert' show jsonEncode;
 import 'dart:io';
 
 import 'package:flutter/services.dart';
@@ -36,16 +37,22 @@ void main() {
         releaseVersion: '1.0.0+1',
       );
 
+  // Per-test server behavior; the default answers every request 204.
+  late void Function(HttpRequest req) handleRequest;
+
   setUp(() async {
     hashCalls = 0;
     requests = <Uri>[];
     CodePush.debugForceAndroidPlatform = true;
     CodePush.debugResetBaselineHashCache();
+    handleRequest = (HttpRequest req) {
+      req.response.statusCode = HttpStatus.noContent;
+      req.response.close();
+    };
     server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     server.listen((HttpRequest req) {
       requests.add(req.uri);
-      req.response.statusCode = HttpStatus.noContent;
-      req.response.close();
+      handleRequest(req);
     });
   });
 
@@ -107,6 +114,63 @@ void main() {
         requests.last.queryParameters.containsKey('baseline_hash'),
         isFalse,
       );
+    });
+
+    test(
+        'soft-gate mismatch: hash computed once within a check, telemetry '
+        'reported once across checks', () async {
+      mockAppLibHash(fakeHash);
+
+      // A code-push-capable engine, so the flow reaches the soft gate.
+      const engineChannel = MethodChannel(
+        'flutter/codepush',
+        JSONMethodCodec(),
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(engineChannel, (MethodCall call) async {
+        if (call.method == 'CodePush.getEngineAbi') return 'test-abi';
+        return null;
+      });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(engineChannel, null);
+      });
+
+      var telemetryPosts = 0;
+      final mismatchingHash = 'b' * 64;
+      handleRequest = (HttpRequest req) {
+        if (req.uri.path.endsWith('/api/v1/updates')) {
+          req.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(jsonEncode(<String, dynamic>{
+              'patch_available': true,
+              'patch_id': 'p1',
+              'patch_url': 'http://127.0.0.1:${server.port}/patch',
+              'baseline_hash': mismatchingHash,
+            }));
+        } else if (req.uri.path.endsWith('/api/v1/telemetry/client-error')) {
+          telemetryPosts++;
+          req.response.statusCode = HttpStatus.ok;
+        } else {
+          // Patch download — fail it so the check exits after the gate.
+          req.response.statusCode = HttpStatus.notFound;
+        }
+        req.response.close();
+      };
+
+      // Within one check the hash is computed at the query step AND the
+      // soft-gate step — the shared cache/in-flight future must collapse
+      // that to a single platform-channel invocation.
+      await check();
+      expect(hashCalls, 1);
+      expect(telemetryPosts, 1);
+
+      // A second check sees the same mismatch pair — already reported,
+      // so no further telemetry.
+      await check();
+      expect(hashCalls, 1);
+      expect(telemetryPosts, 1);
     });
   });
 }


### PR DESCRIPTION
## What
Adds Android support to `_computeBaselineHash()`. Until now the SDK returned `null` off-iOS, so **Android devices sent no `baseline_hash`** on the `/updates` check — meaning the server's baseline gate had nothing to compare and always fell through to serve. This makes the device compute and send it, so server-side baseline targeting can actually take effect on Android.

## How (Approach A — SDK plugin)
- New Android plugin (Kotlin): `android/…/FlutterplazaCodePushPlugin.kt` exposes `getAppLibHash` on the existing `flutterplaza_code_push` channel. It SHA-256s `lib/<abi>/libapp.so` **read straight from the installed APK/split zip** (via `applicationInfo.sourceDir` + `splitSourceDirs`), returning lowercase hex — the same format the iOS path already produces.
- Dart: `_computeBaselineHash()` gets an Android branch that calls it (2 s timeout, cached, fails soft to `null`).
- `pubspec.yaml`: declares the `android` plugin platform.

### Why read the APK bytes (not the loaded module / not the engine)
The server hashes the packaged **file**. Reading the archived `libapp.so` entry reproduces those exact bytes regardless of `extractNativeLibs`, so the device digest matches the server's by construction. Doing this in the SDK plugin (vs an engine method) avoids an engine rebuild and keeps the hash source honest. Per arch.md §17 the baseline-hash mechanism is publishable; the method name is deliberately generic and the code reveals nothing about the gate/format.

## Safety — fails **closed**, never bricks
If the hash can't be computed → `null` → prior behavior. If it mismatches: the **server** returns 204 (no patch) and the **device** load-time check is soft (telemetry only, still proceeds). Worst case is "a patch doesn't apply," never a crash.

## ⚠️ Paired with server task #23 before it's trustworthy
The server's stored `baseline_hash` must be computed over the **same stripped, packaged** `libapp.so` the device loads. Until code-push-server #23 reconciles that, a *correct* baseline could hash-mismatch (→ patch withheld, safe). **The device round-trip is the real proof:** build a release, upload, confirm the device's `getAppLibHash` == the server's stored hash == a patch is served and applies.

## Notes for review / device test
- **Base is the checkpoint (rc.6) lineage**, not `main` — `main` (0.1.10+1) is behind and diverged (a separate SDK reconcile, mirroring the server, is a follow-up).
- No version bump / CHANGELOG here — that's the publish step (your call).
- Pre-existing `avoid_print` "remove before publish" diagnostics left in place; they're handy for confirming the hash is on the wire during the device test.
- Kotlin compiles only in a real Android build — needs your on-device pass.