### PR TITLE
ci: structured single-comment review bot, complexity-routed model

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,39 +18,82 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Route the review model by PR complexity: small mechanical diffs get
+      # Haiku, standard changes get Sonnet, and large or sensitive-path
+      # changes (device-shipping native/plugin code, the core Dart update
+      # path, CI) get Opus.
+      - name: Pick review model by complexity
+        id: model
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CHANGED=$(( ${{ github.event.pull_request.additions }} + ${{ github.event.pull_request.deletions }} ))
+          SENSITIVE=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo "${{ github.repository }}" --json files \
+            -q '[.files[].path | select(test("^(android/|ios/|lib/src/code_push\\.dart|\\.github/workflows/)"))] | length' || echo 1)
+          if [ "$CHANGED" -le 60 ] && [ "$SENSITIVE" -eq 0 ]; then
+            MODEL=claude-haiku-4-5-20251001
+          elif [ "$CHANGED" -le 1200 ] && [ "$SENSITIVE" -eq 0 ]; then
+            MODEL=claude-sonnet-5
+          else
+            MODEL=claude-opus-4-8
+          fi
+          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+          echo "changed=$CHANGED sensitive=$SENSITIVE model=$MODEL"
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this pull request as a senior Flutter plugin engineer.
+            Review this Flutter plugin pull request. This plugin provides
+            over-the-air code push updates for Flutter apps — update checks,
+            patch download and install, and rollback — on Android and iOS.
 
-            Classify every finding by severity and lead each one with its
-            label:
-            - **Critical** — bugs, broken behavior, data loss, security
-              flaws. Only Critical findings block merging.
-            - **Medium** — real but non-blocking improvements; the team may
-              table these as tracked follow-ups.
-            - **Low** — style, polish, minor hardening.
+            Focus on:
+            - Correctness bugs and edge cases
+            - Platform-channel consistency (Dart API vs the Android/iOS
+              implementations)
+            - Breaking changes to the public API for existing package users
+            - Failure-soft behavior: the update path must never crash or
+              brick a host app
+            - Test coverage for new behavior
+            - Security (network handling, file I/O, patch validation)
 
-            Before raising a finding, read the PR's existing comments and
-            review threads (`gh pr view <n> --comments`). Do not re-raise a
-            finding the author has already refuted or explicitly tabled
-            there unless you have new evidence. When claiming a control-flow
-            gap (e.g. a missing try/finally), read the entire enclosing
-            function first and cite the line numbers that demonstrate it.
+            Before raising a finding, read the PR's existing comments
+            (`gh pr view <n> --comments`). Do not re-raise a finding the
+            author has already refuted or explicitly tabled there unless you
+            have new evidence. When claiming a control-flow gap (e.g. a
+            missing try/finally), read the entire enclosing function first
+            and cite the line numbers that demonstrate it.
 
-            Focus on correctness bugs and edge cases, API misuse,
-            error-handling gaps, security issues, and backwards
-            compatibility for existing users. Skip pure style nits.
+            Post your review as a SINGLE comment using one `gh pr comment`
+            call — do not post multiple comments or inline comments.
 
-            Use `gh pr comment` for the summary and
-            `mcp__github_inline_comment__create_inline_comment` (with
-            confirmed: true) for line-specific issues. Only post GitHub
-            comments — do not submit review text as plain messages.
+            Structure the comment with exactly these sections, in this order:
+
+            ## 🔴 Critical
+            Bugs, crashes, security issues, breaking changes — anything that
+            must be fixed before merging. Only Critical findings block the
+            merge. Write "None" if there are none.
+
+            ## 🟠 Medium
+            Issues that should be addressed but don't block the merge
+            (missing edge-case handling, missing tests). The team may table
+            these as tracked follow-ups. Write "None" if there are none.
+
+            ## 🟡 Low
+            Minor improvements and suggestions. Write "None" if there are none.
+
+            ## 🟢 Positives
+            What the PR does well.
+
+            For each finding, reference the file and line (e.g. `lib/foo.dart:42`)
+            and explain briefly why it matters. Keep it concise and only flag
+            issues that matter — skip style nitpicks already covered by
+            `dart format` and `dart analyze`.
           claude_args: |
-            --model claude-sonnet-4-6
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model ${{ steps.model.outputs.model }}
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Unifies the Claude review bot across the FlutterPlaza repos:

- **One structured comment** per review (single `gh pr comment`; no inline comments): sections 🔴 Critical / 🟠 Medium / 🟡 Low / 🟢 Positives, with "None" when a section is empty, `file:line` references, and only-Critical-blocks semantics.
- **Model routed by PR complexity** instead of a fixed pin: a pre-step picks Haiku (small mechanical diffs), Sonnet (standard), or Opus (large diffs or sensitive paths) from the PR's size and touched paths.
- Keeps the anti-noise guardrails (read existing comments before re-raising; cite enclosing-function lines for control-flow claims) and the fork-secrets guard.

Note: the review bot self-skips on this PR itself — the action only runs a workflow file that matches the default branch's copy. First effective run is the next PR after merge.