### PR TITLE
OTA controls: server-side disable signal + store-only install option

### DIFF
--- a/android/src/main/kotlin/com/flutterplaza/flutterplaza_code_push/FlutterplazaCodePushPlugin.kt
+++ b/android/src/main/kotlin/com/flutterplaza/flutterplaza_code_push/FlutterplazaCodePushPlugin.kt
@@ -50,7 +50,23 @@ class FlutterplazaCodePushPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
           }
         }.start()
       }
-      "getInstallerSource" -> result.success(installerSource())
+      "getInstallerSource" -> {
+        // Off the platform thread like getAppLibHash: the package-manager
+        // binder call is normally fast, but it should never be able to
+        // stall the main thread during startup.
+        val handler = Handler(Looper.getMainLooper())
+        Thread {
+          val installer = installerSource()
+          handler.post {
+            if (!attached) return@post
+            try {
+              result.success(installer)
+            } catch (_: Exception) {
+              // Messenger torn down; the Dart side times out on its own.
+            }
+          }
+        }.start()
+      }
       else -> result.notImplemented()
     }
   }

--- a/android/src/main/kotlin/com/flutterplaza/flutterplaza_code_push/FlutterplazaCodePushPlugin.kt
+++ b/android/src/main/kotlin/com/flutterplaza/flutterplaza_code_push/FlutterplazaCodePushPlugin.kt
@@ -50,9 +50,26 @@ class FlutterplazaCodePushPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
           }
         }.start()
       }
+      "getInstallerSource" -> result.success(installerSource())
       else -> result.notImplemented()
     }
   }
+
+  /**
+   * Package name of the installer that placed this app (for example
+   * "com.android.vending" for the Play Store), or null when unknown or
+   * sideloaded. Lets the Dart side honor a developer's choice to keep
+   * OTA updates off for store-installed builds.
+   */
+  private fun installerSource(): String? = runCatching {
+    val pm = context.packageManager
+    if (Build.VERSION.SDK_INT >= 30) {
+      pm.getInstallSourceInfo(context.packageName).installingPackageName
+    } else {
+      @Suppress("DEPRECATION")
+      pm.getInstallerPackageName(context.packageName)
+    }
+  }.getOrNull()
 
   /**
    * SHA-256 (lowercase hex) of lib/<abi>/libapp.so as packaged in the

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -152,6 +152,13 @@ abstract final class CodePush {
       // without the plugin (debug, sideload) is not a store install.
       if (disableOnPlayStoreInstalls && await isPlayStoreInstall()) {
         status.value = 'OTA off (store-installed build)';
+        // A native crash-loop rollback recorded before Dart started is
+        // still history worth reporting (and its marker worth
+        // clearing), even though OTA is off from here on.
+        await _reportPendingNativeRollback(
+          serverUrl: serverUrl,
+          appId: appId,
+        );
         try {
           // rollback() removes the patch wherever the platform keeps it
           // (engine on Android/desktop, direct file removal on iOS) and

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show Timer;
+import 'dart:async' show Timer, unawaited;
 import 'dart:convert' show base64Encode, jsonDecode, jsonEncode, utf8;
 import 'dart:io' show Directory, File, FileMode, HttpClient, Platform, exit;
 
@@ -114,6 +114,7 @@ abstract final class CodePush {
     Duration interval = const Duration(hours: 4),
     String channel = 'production',
     VoidCallback? onUpdateReady,
+    bool disableOnPlayStoreInstalls = false,
   }) {
     print('[CP-INIT] CodePush.init called');
     // Store the config so `CodePushOverlay` can reuse it without
@@ -124,6 +125,7 @@ abstract final class CodePush {
       releaseVersion: releaseVersion,
       checkInterval: interval,
       channel: channel,
+      disableOnPlayStoreInstalls: disableOnPlayStoreInstalls,
     );
 
     // NOTE: Any stale-patch cleanup from prior versions (0.1.4/0.1.5)
@@ -135,6 +137,47 @@ abstract final class CodePush {
 
     _timer?.cancel();
 
+    unawaited(() async {
+      // Developer-selected store-only mode: when enabled and this build
+      // was installed from the Play Store, OTA stays off for the whole
+      // session — no server checks — and any patch left over from
+      // before the setting shipped is removed so the device runs the
+      // store baseline. Detection failure leaves OTA enabled: a build
+      // without the plugin (debug, sideload) is not a store install.
+      if (disableOnPlayStoreInstalls && await isPlayStoreInstall()) {
+        status.value = 'OTA off (store-installed build)';
+        try {
+          if (await isPatched) {
+            await rollback();
+            status.value = 'OTA off (store-installed build) — patch removed';
+          }
+        } catch (_) {
+          // Best-effort: nothing to revert on a clean device.
+        }
+        return;
+      }
+      _startUpdateFlow(
+        serverUrl: serverUrl,
+        appId: appId,
+        releaseVersion: releaseVersion,
+        interval: interval,
+        channel: channel,
+        onUpdateReady: onUpdateReady,
+      );
+    }());
+  }
+
+  /// Starts crash protection, the first update check, and the periodic
+  /// check timer. Split out of [init] so the store-install gate can
+  /// decide whether the flow starts at all.
+  static void _startUpdateFlow({
+    required String serverUrl,
+    required String appId,
+    required String releaseVersion,
+    required Duration interval,
+    required String channel,
+    VoidCallback? onUpdateReady,
+  }) {
     // Crash protection runs async because it needs the engine's patch
     // dir via platform channel. We chain the first checkAndInstall off
     // it so that, on a boot where a previously-downloaded bad patch is
@@ -221,6 +264,25 @@ abstract final class CodePush {
       }
 
       final data = jsonDecode(r.body) as Map<String, dynamic>;
+
+      // Fleet-wide OTA kill switch (server-controlled). When the server
+      // says OTA is off for this app, stop offering updates AND revert
+      // any installed patch, so the fleet returns to the store baseline
+      // within one check interval of the switch being flipped.
+      if (data['ota_disabled'] == true) {
+        status.value = 'OTA disabled by server';
+        try {
+          if (await isPatched) {
+            await rollback();
+            status.value =
+                'OTA disabled by server — patch removed (restart to apply)';
+          }
+        } catch (_) {
+          // Best-effort: a clean device has nothing to revert.
+        }
+        return false;
+      }
+
       if (data['patch_available'] != true) {
         status.value = 'No patch available';
         return false;
@@ -728,10 +790,39 @@ abstract final class CodePush {
     _baselineHashFailedAt = null;
     _baselineHashInFlight = null;
     _reportedBaselineMismatches.clear();
+    _cachedIsPlayInstall = null;
   }
 
   /// Cached distribution-proof baseline UUID (see [_readBaselineId]).
   static String? _cachedBaselineId;
+
+  /// Cached installer-source verdict for the session.
+  static bool? _cachedIsPlayInstall;
+
+  /// Whether this build was installed by the Google Play Store.
+  ///
+  /// Backs [init]'s `disableOnPlayStoreInstalls`: developers who want
+  /// store-only updates for Play-installed builds set that flag, and
+  /// this check decides whether it applies to the running install.
+  /// Only meaningful on Android; false elsewhere and on any failure
+  /// (a build without the plugin — debug, sideload — is not a store
+  /// install, so failing open keeps OTA available where it is allowed).
+  @visibleForTesting
+  static Future<bool> isPlayStoreInstall() async {
+    final cached = _cachedIsPlayInstall;
+    if (cached != null) return cached;
+    try {
+      if (!(debugForceAndroidPlatform || Platform.isAndroid)) {
+        return _cachedIsPlayInstall = false;
+      }
+      final installer = await _pluginChannel
+          .invokeMethod<String>('getInstallerSource')
+          .timeout(const Duration(seconds: 2));
+      return _cachedIsPlayInstall = installer == 'com.android.vending';
+    } catch (_) {
+      return _cachedIsPlayInstall = false;
+    }
+  }
 
   /// Read the distribution-proof baseline UUID from Info.plist
   /// (`FCPBaselineId` key, written by `fcp codepush release`).
@@ -1254,6 +1345,7 @@ class CodePushConfig {
     required this.releaseVersion,
     this.checkInterval = const Duration(hours: 4),
     this.channel = 'production',
+    this.disableOnPlayStoreInstalls = false,
   });
 
   final String serverUrl;
@@ -1261,6 +1353,12 @@ class CodePushConfig {
   final String releaseVersion;
   final Duration checkInterval;
   final String channel;
+
+  /// Keep OTA updates off for builds installed from the Play Store, so
+  /// those installs only ever change through store updates. Off-store
+  /// installs (sideload, other stores, MDM) are unaffected. Off by
+  /// default.
+  final bool disableOnPlayStoreInstalls;
 }
 
 /// A widget that wraps your app and shows an update-ready banner
@@ -1352,6 +1450,7 @@ class _CodePushOverlayState extends State<CodePushOverlay>
       releaseVersion: cfg.releaseVersion,
       interval: cfg.checkInterval,
       channel: cfg.channel,
+      disableOnPlayStoreInstalls: cfg.disableOnPlayStoreInstalls,
       onUpdateReady: () {
         if (mounted) setState(() => _updateReady = true);
       },

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -67,6 +67,11 @@ abstract final class CodePush {
   static Timer? _timer;
   static Timer? _launchTimer;
 
+  /// Bumped by every [init] and [dispose]; async init work checks it
+  /// after each await so a stale closure can't start timers for a
+  /// session that was disposed or re-initialized mid-flight.
+  static int _initEpoch = 0;
+
   /// Maximum consecutive failed boots before auto-rollback.
   static const int _maxBootAttempts = 3;
 
@@ -137,6 +142,7 @@ abstract final class CodePush {
 
     _timer?.cancel();
 
+    final epoch = ++_initEpoch;
     unawaited(() async {
       // Developer-selected store-only mode: when enabled and this build
       // was installed from the Play Store, OTA stays off for the whole
@@ -147,15 +153,20 @@ abstract final class CodePush {
       if (disableOnPlayStoreInstalls && await isPlayStoreInstall()) {
         status.value = 'OTA off (store-installed build)';
         try {
-          if (await isPatched) {
-            await rollback();
-            status.value = 'OTA off (store-installed build) — patch removed';
-          }
+          // rollback() removes the patch wherever the platform keeps it
+          // (engine on Android/desktop, direct file removal on iOS) and
+          // throws when there is nothing to remove — the common,
+          // healthy case, swallowed below.
+          await rollback();
+          status.value = 'OTA off (store-installed build) — patch removed';
         } catch (_) {
-          // Best-effort: nothing to revert on a clean device.
+          // Nothing to revert.
         }
         return;
       }
+      // A dispose() or a newer init() during the await above owns the
+      // session now — don't start timers for a stale one.
+      if (epoch != _initEpoch) return;
       _startUpdateFlow(
         serverUrl: serverUrl,
         appId: appId,
@@ -221,6 +232,7 @@ abstract final class CodePush {
 
   /// Stops automatic update checking and cancels the launch timer.
   static void dispose() {
+    _initEpoch++;
     _timer?.cancel();
     _timer = null;
     _launchTimer?.cancel();
@@ -272,11 +284,14 @@ abstract final class CodePush {
       if (data['ota_disabled'] == true) {
         status.value = 'OTA disabled by server';
         try {
-          if (await isPatched) {
-            await rollback();
-            status.value =
-                'OTA disabled by server — patch removed (restart to apply)';
-          }
+          // Unconditional: rollback() knows where each platform keeps
+          // the patch (engine on Android/desktop, file removal on iOS
+          // where the engine channel is disabled and isPatched would
+          // always answer false) and throws harmlessly when the device
+          // is already clean.
+          await rollback();
+          status.value =
+              'OTA disabled by server — patch removed (restart to apply)';
         } catch (_) {
           // Best-effort: a clean device has nothing to revert.
         }
@@ -820,7 +835,10 @@ abstract final class CodePush {
           .timeout(const Duration(seconds: 2));
       return _cachedIsPlayInstall = installer == 'com.android.vending';
     } catch (_) {
-      return _cachedIsPlayInstall = false;
+      // Transient failure (slow first boot, torn-down messenger): fail
+      // open for this call but do NOT cache it, so the next init or
+      // check re-asks instead of pinning the wrong answer all session.
+      return false;
     }
   }
 

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -151,6 +151,12 @@ abstract final class CodePush {
       // store baseline. Detection failure leaves OTA enabled: a build
       // without the plugin (debug, sideload) is not a store install.
       if (disableOnPlayStoreInstalls && await isPlayStoreInstall()) {
+        // Stale-session check after EVERY await in this branch: its
+        // side effects (a telemetry POST, a patch deletion) must never
+        // fire for a session that was disposed or superseded while a
+        // lookup was in flight — a stale rollback could even delete a
+        // patch a newer session just installed.
+        if (epoch != _initEpoch) return;
         status.value = 'OTA off (store-installed build)';
         // A native crash-loop rollback recorded before Dart started is
         // still history worth reporting (and its marker worth
@@ -159,6 +165,7 @@ abstract final class CodePush {
           serverUrl: serverUrl,
           appId: appId,
         );
+        if (epoch != _initEpoch) return;
         try {
           // rollback() removes the patch wherever the platform keeps it
           // (engine on Android/desktop, direct file removal on iOS) and

--- a/test/crash_protection_test.dart
+++ b/test/crash_protection_test.dart
@@ -425,7 +425,8 @@ void main() {
       expect(File('$patchDir/patch.bytecode').existsSync(), isFalse);
     });
 
-    test('after immediate rollback, new patch can be installed fresh', () async {
+    test('after immediate rollback, new patch can be installed fresh',
+        () async {
       // Bad patch triggers immediate rollback.
       File('$patchDir/patch.bytecode').writeAsBytesSync([0xBA, 0xD0]);
       _writeBootCounter(patchDir, 1);

--- a/test/ota_controls_test.dart
+++ b/test/ota_controls_test.dart
@@ -148,6 +148,39 @@ void main() {
       expect(engineLog, contains('CodePush.rollback'));
     });
 
+    test(
+        'dispose during the installer lookup wins: no ownerless flow starts '
+        '(epoch regression test)', () async {
+      CodePush.debugForceAndroidPlatform = true;
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(pluginChannel,
+          (MethodCall call) async {
+        if (call.method == 'getInstallerSource') {
+          // Hold the answer long enough for dispose() to land inside
+          // the await gap, then answer "not a Play install" — the path
+          // that would otherwise proceed to start the update flow.
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+          return null;
+        }
+        return null;
+      });
+      messenger.setMockMethodCallHandler(
+          engineChannel, (MethodCall call) async => null);
+
+      CodePush.init(
+        serverUrl: 'http://127.0.0.1:${server.port}',
+        appId: 'test-app',
+        releaseVersion: '1.0.0+1',
+        disableOnPlayStoreInstalls: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      CodePush.dispose();
+      await Future<void>.delayed(const Duration(milliseconds: 600));
+
+      expect(requests, isEmpty);
+    });
+
     test('non-Play install + flag: the update flow runs normally', () async {
       CodePush.debugForceAndroidPlatform = true;
       mockChannels(installer: null);

--- a/test/ota_controls_test.dart
+++ b/test/ota_controls_test.dart
@@ -1,0 +1,143 @@
+import 'dart:convert' show jsonEncode;
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterplaza_code_push/flutterplaza_code_push.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  // The test binding stubs HttpClient to a 400-only fake; these tests
+  // need the real loopback stack to reach the local capture server.
+  HttpOverrides.global = null;
+
+  const pluginChannel = MethodChannel('flutterplaza_code_push');
+  const engineChannel = MethodChannel('flutter/codepush', JSONMethodCodec());
+
+  late HttpServer server;
+  late void Function(HttpRequest req) handleRequest;
+
+  Future<bool> check() => CodePush.checkAndInstall(
+        serverUrl: 'http://127.0.0.1:${server.port}',
+        appId: 'test-app',
+        releaseVersion: '1.0.0+1',
+      );
+
+  void serveOtaDisabled() {
+    handleRequest = (HttpRequest req) {
+      req.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode(<String, dynamic>{
+            'patch_available': false,
+            'ota_disabled': true,
+          }),
+        );
+      req.response.close();
+    };
+  }
+
+  setUp(() async {
+    CodePush.debugResetBaselineHashCache();
+    handleRequest = (HttpRequest req) {
+      req.response.statusCode = HttpStatus.noContent;
+      req.response.close();
+    };
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((HttpRequest req) => handleRequest(req));
+  });
+
+  tearDown(() async {
+    CodePush.debugForceAndroidPlatform = false;
+    CodePush.debugResetBaselineHashCache();
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(pluginChannel, null);
+    messenger.setMockMethodCallHandler(engineChannel, null);
+    await server.close(force: true);
+  });
+
+  group('server kill switch', () {
+    test('unpatched device: stops quietly, no rollback attempted', () async {
+      serveOtaDisabled();
+      final engineCalls = <String>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(engineChannel, (MethodCall call) async {
+        engineCalls.add(call.method);
+        if (call.method == 'CodePush.isPatched') return false;
+        return null;
+      });
+
+      final installed = await check();
+
+      expect(installed, isFalse);
+      expect(CodePush.status.value, contains('OTA disabled'));
+      expect(engineCalls, contains('CodePush.isPatched'));
+      expect(engineCalls, isNot(contains('CodePush.rollback')));
+    });
+
+    test('patched device: reverts to the store baseline', () async {
+      serveOtaDisabled();
+      final engineCalls = <String>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(engineChannel, (MethodCall call) async {
+        engineCalls.add(call.method);
+        if (call.method == 'CodePush.isPatched') return true;
+        if (call.method == 'CodePush.rollback') return true;
+        return null;
+      });
+
+      final installed = await check();
+
+      expect(installed, isFalse);
+      expect(
+        engineCalls.where((m) => m == 'CodePush.rollback'),
+        hasLength(1),
+      );
+      expect(CodePush.status.value, contains('patch removed'));
+    });
+  });
+
+  group('isPlayStoreInstall', () {
+    late int installerCalls;
+
+    void mockInstaller(String? installer) {
+      installerCalls = 0;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(pluginChannel, (MethodCall call) async {
+        if (call.method == 'getInstallerSource') {
+          installerCalls++;
+          return installer;
+        }
+        return null;
+      });
+    }
+
+    test('true for a Play-installed Android build, cached per session',
+        () async {
+      CodePush.debugForceAndroidPlatform = true;
+      mockInstaller('com.android.vending');
+
+      expect(await CodePush.isPlayStoreInstall(), isTrue);
+      expect(await CodePush.isPlayStoreInstall(), isTrue);
+      expect(installerCalls, 1);
+    });
+
+    test('false for other installers and sideloads', () async {
+      CodePush.debugForceAndroidPlatform = true;
+      mockInstaller('com.sec.android.app.samsungapps');
+      expect(await CodePush.isPlayStoreInstall(), isFalse);
+
+      CodePush.debugResetBaselineHashCache();
+      mockInstaller(null);
+      expect(await CodePush.isPlayStoreInstall(), isFalse);
+    });
+
+    test('false off Android without touching the channel', () async {
+      mockInstaller('com.android.vending');
+      expect(await CodePush.isPlayStoreInstall(), isFalse);
+      expect(installerCalls, 0);
+    });
+  });
+}

--- a/test/ota_controls_test.dart
+++ b/test/ota_controls_test.dart
@@ -59,13 +59,15 @@ void main() {
   });
 
   group('server kill switch', () {
-    test('unpatched device: stops quietly, no rollback attempted', () async {
+    test('clean device: stops quietly, revert attempt no-ops', () async {
       serveOtaDisabled();
       final engineCalls = <String>[];
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(engineChannel, (MethodCall call) async {
         engineCalls.add(call.method);
-        if (call.method == 'CodePush.isPatched') return false;
+        // Engine says the rollback did not apply; the Dart file
+        // fallback then finds no patch dir and throws (swallowed).
+        if (call.method == 'CodePush.rollback') return false;
         return null;
       });
 
@@ -73,8 +75,7 @@ void main() {
 
       expect(installed, isFalse);
       expect(CodePush.status.value, contains('OTA disabled'));
-      expect(engineCalls, contains('CodePush.isPatched'));
-      expect(engineCalls, isNot(contains('CodePush.rollback')));
+      expect(CodePush.status.value, isNot(contains('patch removed')));
     });
 
     test('patched device: reverts to the store baseline', () async {
@@ -83,7 +84,6 @@ void main() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(engineChannel, (MethodCall call) async {
         engineCalls.add(call.method);
-        if (call.method == 'CodePush.isPatched') return true;
         if (call.method == 'CodePush.rollback') return true;
         return null;
       });
@@ -96,6 +96,75 @@ void main() {
         hasLength(1),
       );
       expect(CodePush.status.value, contains('patch removed'));
+    });
+  });
+
+  group('init store-install gate', () {
+    late List<Uri> requests;
+
+    setUp(() {
+      requests = <Uri>[];
+      handleRequest = (HttpRequest req) {
+        requests.add(req.uri);
+        req.response.statusCode = HttpStatus.noContent;
+        req.response.close();
+      };
+    });
+
+    tearDown(CodePush.dispose);
+
+    void mockChannels({required String? installer, List<String>? engineLog}) {
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(pluginChannel,
+          (MethodCall call) async {
+        if (call.method == 'getInstallerSource') return installer;
+        return null;
+      });
+      messenger.setMockMethodCallHandler(engineChannel,
+          (MethodCall call) async {
+        engineLog?.add(call.method);
+        if (call.method == 'CodePush.rollback') return true;
+        return null;
+      });
+    }
+
+    test('Play install + flag: no update flow starts, leftover patch removed',
+        () async {
+      CodePush.debugForceAndroidPlatform = true;
+      final engineLog = <String>[];
+      mockChannels(installer: 'com.android.vending', engineLog: engineLog);
+
+      CodePush.init(
+        serverUrl: 'http://127.0.0.1:${server.port}',
+        appId: 'test-app',
+        releaseVersion: '1.0.0+1',
+        disableOnPlayStoreInstalls: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(requests, isEmpty);
+      expect(CodePush.status.value, contains('OTA off'));
+      expect(engineLog, contains('CodePush.rollback'));
+    });
+
+    test('non-Play install + flag: the update flow runs normally', () async {
+      CodePush.debugForceAndroidPlatform = true;
+      mockChannels(installer: null);
+
+      CodePush.init(
+        serverUrl: 'http://127.0.0.1:${server.port}',
+        appId: 'test-app',
+        releaseVersion: '1.0.0+1',
+        disableOnPlayStoreInstalls: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+
+      expect(requests, isNotEmpty);
+      expect(
+        requests.first.path.endsWith('/api/v1/updates'),
+        isTrue,
+      );
     });
   });
 

--- a/test/ota_controls_test.dart
+++ b/test/ota_controls_test.dart
@@ -181,6 +181,42 @@ void main() {
       expect(requests, isEmpty);
     });
 
+    test(
+        'dispose during the lookup also quiesces the Play/store-off branch: '
+        'no telemetry, no rollback', () async {
+      CodePush.debugForceAndroidPlatform = true;
+      final engineLog = <String>[];
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(pluginChannel,
+          (MethodCall call) async {
+        if (call.method == 'getInstallerSource') {
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+          return 'com.android.vending';
+        }
+        return null;
+      });
+      messenger.setMockMethodCallHandler(engineChannel,
+          (MethodCall call) async {
+        engineLog.add(call.method);
+        if (call.method == 'CodePush.rollback') return true;
+        return null;
+      });
+
+      CodePush.init(
+        serverUrl: 'http://127.0.0.1:${server.port}',
+        appId: 'test-app',
+        releaseVersion: '1.0.0+1',
+        disableOnPlayStoreInstalls: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      CodePush.dispose();
+      await Future<void>.delayed(const Duration(milliseconds: 600));
+
+      expect(requests, isEmpty);
+      expect(engineLog, isNot(contains('CodePush.rollback')));
+    });
+
     test('non-Play install + flag: the update flow runs normally', () async {
       CodePush.debugForceAndroidPlatform = true;
       mockChannels(installer: null);


### PR DESCRIPTION
## What
Two operational controls, both off/inert by default:

1. **Server-side OTA disable signal.** When the update check answers `ota_disabled: true`, the SDK stops offering updates and reverts any installed patch (engine rollback, iOS file fallback) — the device returns to its store baseline and re-checks on the normal cadence, so re-enabling on the server resumes service with no app update. Servers that never send the field see zero behavior change.
2. **`disableOnPlayStoreInstalls` (init + CodePushConfig, default `false`).** Developers who want Play-installed builds to change only through store updates set this flag: on such installs the update flow doesn't start and any leftover patch is removed. Sideloads and other stores are unaffected. Detection uses the platform installer-source API (`getInstallSourceInfo` on API 30+, legacy fallback below); on failure OTA stays enabled, since a build without the plugin (debug/sideload) is not a store install.

## Companion
Server side of the disable signal: FlutterPlaza/code-push-server#16.

## Tests
5 new (68/68 total): kill-signal handling with and without an installed patch (rollback invoked exactly once / not at all), installer detection incl. session caching and the non-Android short-circuit. Analyze clean.