### PR TITLE
Quarantine a rolled-back patch so a bad patch can't crash-loop forever (finding #7)

### DIFF
--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -848,6 +848,14 @@ abstract final class CodePush {
   /// re-quarantine a good patch that was installed in the meantime, so
   /// the breadcrumb is flagged `quarantined` after the first promotion.
   /// Synchronous, best-effort, idempotent — safe to call more than once.
+  ///
+  /// Cross-component assumption: the native engine (`Updater::Rollback`)
+  /// **replaces** `rollback_info.json` wholesale on each rollback, so a
+  /// new bad patch always arrives as a fresh, unflagged breadcrumb. If a
+  /// future engine ever did a read-modify-write that preserved unknown
+  /// keys, a stale `quarantined` flag would make this early-return and
+  /// the new bad patch would fall back to the engine's three-strike
+  /// protection instead of being quarantined.
   static void _quarantineFromBreadcrumb(String patchDir) {
     try {
       final marker = File('$patchDir/rollback_info.json');

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -208,10 +208,19 @@ abstract final class CodePush {
     // (possibly equally bad) patch. Prior versions fired checkAndInstall
     // unconditionally on init which left no room for the boot counter
     // to trip — see CHANGELOG 0.1.7 for the race condition this fixes.
-    _runCrashProtection().then((_) {
+    _runCrashProtection().then((_) async {
       // Start launch success timer only after crash protection completes,
       // so a rollback doesn't get immediately overwritten by a success report.
       _startLaunchTimer();
+
+      // Quarantine any just-rolled-back patch synchronously BEFORE the
+      // first check, so a bad patch isn't re-downloaded even once on this
+      // boot (the fast, no-network half of the rollback handling). The
+      // telemetry POST below is the slow, best-effort half.
+      final quarantineDir = await _getPatchDir();
+      if (quarantineDir != null) {
+        _quarantineFromBreadcrumb(quarantineDir);
+      }
 
       // Report any rollback that was recorded natively before Dart started
       // (crash-loop protection runs before main(), so without this the
@@ -272,8 +281,7 @@ abstract final class CodePush {
       // (further down) still protects us.
       final deviceBaselineHash = await _computeBaselineHash();
       final deviceBaselineId = await _readBaselineId();
-      final url =
-          '$serverUrl/api/v1/updates'
+      final url = '$serverUrl/api/v1/updates'
           '?app_id=$appId'
           '&version=${Uri.encodeComponent(releaseVersion)}'
           '&platform=$_platform'
@@ -360,8 +368,7 @@ abstract final class CodePush {
           serverUrl: serverUrl,
           appId: appId,
           patchId: patchId,
-          reason:
-              'Engine has no code push support (stock Flutter engine '
+          reason: 'Engine has no code push support (stock Flutter engine '
               'or missing flutter/codepush method channel).',
           expectedFingerprint: expectedEngineFingerprint,
           actualFingerprint: null,
@@ -376,8 +383,7 @@ abstract final class CodePush {
       if (expectedEngineFingerprint != null &&
           actualEngineFingerprint != 'unknown' &&
           expectedEngineFingerprint != actualEngineFingerprint) {
-        status.value =
-            'Incompatible baseline: engine ABI mismatch '
+        status.value = 'Incompatible baseline: engine ABI mismatch '
             '($actualEngineFingerprint vs $expectedEngineFingerprint)';
         await _reportIncompatibleBaseline(
           serverUrl: serverUrl,
@@ -418,8 +424,7 @@ abstract final class CodePush {
             serverUrl: serverUrl,
             appId: appId,
             patchId: patchId,
-            reason:
-                'Baseline hash mismatch (soft gate — proceeding '
+            reason: 'Baseline hash mismatch (soft gate — proceeding '
                 'with download; engine ABI check is the hard gate)',
             expectedFingerprint: expectedBaselineHash,
             actualFingerprint: actualBaselineHash,
@@ -500,8 +505,7 @@ abstract final class CodePush {
                 'HEADER_MISMATCH patchId=$patchId payload=${payload.length}',
               );
             }
-            status.value =
-                'Patch format is unexpected — rolling back. '
+            status.value = 'Patch format is unexpected — rolling back. '
                 'Upgrade flutter_compile to the latest version and '
                 'rebuild the patch.';
             await _iosImmediateRollback(
@@ -691,9 +695,8 @@ abstract final class CodePush {
       final client = HttpClient();
       try {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
-        final req = await client
-            .postUrl(uri)
-            .timeout(const Duration(seconds: 5));
+        final req =
+            await client.postUrl(uri).timeout(const Duration(seconds: 5));
         req.headers.set('Content-Type', 'application/json; charset=utf-8');
         // Send encoded bytes, not a string: HttpClientRequest.write()
         // defaults to Latin-1, which throws on any non-Latin-1 character
@@ -727,6 +730,11 @@ abstract final class CodePush {
       final marker = File('$patchDir/rollback_info.json');
       if (!marker.existsSync()) return;
 
+      // Quarantine the rolled-back patch BEFORE the (best-effort, maybe
+      // offline) telemetry POST, so the crash-loop breaks even with no
+      // network.
+      _quarantineFromBreadcrumb(patchDir);
+
       Map<String, dynamic> info;
       try {
         info = jsonDecode(marker.readAsStringSync()) as Map<String, dynamic>;
@@ -736,22 +744,6 @@ abstract final class CodePush {
           marker.deleteSync();
         } catch (_) {}
         return;
-      }
-
-      // Quarantine the rolled-back patch BEFORE the (best-effort, maybe
-      // offline) telemetry POST, so the crash-loop breaks even with no
-      // network. Do it once per breadcrumb: a rollback_info.json that
-      // lingers offline must not later re-quarantine a good patch that
-      // was installed in the meantime.
-      if (info['quarantined'] != true) {
-        _promoteRolledBackIdentity(patchDir);
-        try {
-          info['quarantined'] = true;
-          marker.writeAsStringSync(jsonEncode(info));
-        } catch (_) {
-          // If we can't flag it, the identity file was already consumed
-          // by the promotion above, so a re-run finds nothing to promote.
-        }
       }
 
       final payload = <String, dynamic>{
@@ -768,9 +760,8 @@ abstract final class CodePush {
       final client = HttpClient();
       try {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
-        final req = await client
-            .postUrl(uri)
-            .timeout(const Duration(seconds: 5));
+        final req =
+            await client.postUrl(uri).timeout(const Duration(seconds: 5));
         req.headers.set('Content-Type', 'application/json; charset=utf-8');
         // Encoded bytes, not a string: write() defaults to Latin-1 and
         // throws on any non-Latin-1 character in the native-written
@@ -848,6 +839,32 @@ abstract final class CodePush {
     } catch (_) {
       // Non-fatal: without it the crash-loop still bottoms out at the
       // engine's three-strike rollback, just without the quarantine.
+    }
+  }
+
+  /// If the engine left a rollback breadcrumb (`rollback_info.json`),
+  /// quarantine the rolled-back patch — but only ONCE per breadcrumb. A
+  /// breadcrumb that lingers offline (telemetry never acked) must not
+  /// re-quarantine a good patch that was installed in the meantime, so
+  /// the breadcrumb is flagged `quarantined` after the first promotion.
+  /// Synchronous, best-effort, idempotent — safe to call more than once.
+  static void _quarantineFromBreadcrumb(String patchDir) {
+    try {
+      final marker = File('$patchDir/rollback_info.json');
+      if (!marker.existsSync()) return;
+      final info =
+          jsonDecode(marker.readAsStringSync()) as Map<String, dynamic>;
+      if (info['quarantined'] == true) return;
+      _promoteRolledBackIdentity(patchDir);
+      try {
+        info['quarantined'] = true;
+        marker.writeAsStringSync(jsonEncode(info));
+      } catch (_) {
+        // If we can't flag it, the identity file was already consumed by
+        // the promotion above, so a re-run finds nothing to re-promote.
+      }
+    } catch (_) {
+      // Best-effort; the three-strike rollback still protects the device.
     }
   }
 
@@ -944,6 +961,10 @@ abstract final class CodePush {
   static void debugPromoteRolledBackIdentity(String patchDir) =>
       _promoteRolledBackIdentity(patchDir);
 
+  @visibleForTesting
+  static void debugQuarantineFromBreadcrumb(String patchDir) =>
+      _quarantineFromBreadcrumb(patchDir);
+
   /// Cached distribution-proof baseline UUID (see [_readBaselineId]).
   static String? _cachedBaselineId;
 
@@ -1030,12 +1051,11 @@ abstract final class CodePush {
         DateTime.now().difference(failedAt) < _baselineHashRetryAfter) {
       return Future.value(null);
     }
-    return _baselineHashInFlight ??= _computeBaselineHashUncached()
-        .then((hash) {
-          if (hash == null) _baselineHashFailedAt = DateTime.now();
-          return hash;
-        })
-        .whenComplete(() => _baselineHashInFlight = null);
+    return _baselineHashInFlight ??=
+        _computeBaselineHashUncached().then((hash) {
+      if (hash == null) _baselineHashFailedAt = DateTime.now();
+      return hash;
+    }).whenComplete(() => _baselineHashInFlight = null);
   }
 
   static Future<String?> _computeBaselineHashUncached() async {
@@ -1562,8 +1582,7 @@ class CodePushOverlay extends StatefulWidget {
     BuildContext context,
     VoidCallback onRestart,
     VoidCallback onDismiss,
-  )?
-  bannerBuilder;
+  )? bannerBuilder;
 
   /// Whether to show the debug status bar at the top. Defaults to false.
   final bool showDebugBar;
@@ -1763,7 +1782,7 @@ class CodePushPatchBuilder extends StatelessWidget {
 
   /// Builder called with the patch data string (or null if no patch).
   final Widget Function(BuildContext context, String? patchData, Widget? child)
-  builder;
+      builder;
 
   /// Optional child widget passed to the builder (typically the default/baseline UI).
   final Widget? child;

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -855,14 +855,15 @@ abstract final class CodePush {
       final info =
           jsonDecode(marker.readAsStringSync()) as Map<String, dynamic>;
       if (info['quarantined'] == true) return;
+      // Flag the breadcrumb BEFORE promoting, so this is all-or-nothing:
+      // if the flag write throws, we return WITHOUT consuming the identity
+      // (a later boot retries cleanly). The alternative order could leave
+      // the breadcrumb unflagged AND the identity consumed — and if a good
+      // patch were installed before the next boot, the still-live
+      // breadcrumb would then quarantine that good patch.
+      info['quarantined'] = true;
+      marker.writeAsStringSync(jsonEncode(info));
       _promoteRolledBackIdentity(patchDir);
-      try {
-        info['quarantined'] = true;
-        marker.writeAsStringSync(jsonEncode(info));
-      } catch (_) {
-        // If we can't flag it, the identity file was already consumed by
-        // the promotion above, so a re-run finds nothing to re-promote.
-      }
     } catch (_) {
       // Best-effort; the three-strike rollback still protects the device.
     }

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -161,10 +161,7 @@ abstract final class CodePush {
         // A native crash-loop rollback recorded before Dart started is
         // still history worth reporting (and its marker worth
         // clearing), even though OTA is off from here on.
-        await _reportPendingNativeRollback(
-          serverUrl: serverUrl,
-          appId: appId,
-        );
+        await _reportPendingNativeRollback(serverUrl: serverUrl, appId: appId);
         if (epoch != _initEpoch) return;
         try {
           // rollback() removes the patch wherever the platform keeps it
@@ -275,7 +272,8 @@ abstract final class CodePush {
       // (further down) still protects us.
       final deviceBaselineHash = await _computeBaselineHash();
       final deviceBaselineId = await _readBaselineId();
-      final url = '$serverUrl/api/v1/updates'
+      final url =
+          '$serverUrl/api/v1/updates'
           '?app_id=$appId'
           '&version=${Uri.encodeComponent(releaseVersion)}'
           '&platform=$_platform'
@@ -318,53 +316,29 @@ abstract final class CodePush {
       }
 
       final patchId = data['patch_id']?.toString();
+      final serverPatchHash = data['patch_hash']?.toString();
       final patchUrl = data['patch_url'] as String?;
       if (patchUrl == null || patchUrl.isEmpty) {
         status.value = 'No patch URL';
         return false;
       }
 
-      // Check if this patch was previously rolled back.  The rollback
-      // marker persists across cold starts so the same bad patch isn't
-      // re-downloaded in a crash loop.
-      if (Platform.isIOS) {
-        final patchDir = await _getPatchDir();
-        if (patchDir != null) {
-          final rbFile = File('$patchDir/rolled_back_patch');
-          if (rbFile.existsSync()) {
-            try {
-              final rb =
-                  jsonDecode(rbFile.readAsStringSync()) as Map<String, dynamic>;
-              final rbId = rb['patch_id']?.toString();
-              final rbHash = rb['patch_hash']?.toString();
-              final serverPatchId = patchId;
-              final serverPatchHash = data['patch_hash']?.toString();
-              final idMatch = rbId != null && rbId == serverPatchId;
-              final hashMatch = rbHash != null &&
-                  serverPatchHash != null &&
-                  rbHash == serverPatchHash;
-              print(
-                '[CP] rollback check: rbId=$rbId serverId=$serverPatchId '
-                'idMatch=$idMatch rbHash=${rbHash?.substring(0, 8)}... '
-                'serverHash=${serverPatchHash?.substring(0, 8)}... '
-                'hashMatch=$hashMatch',
-              );
-              if (idMatch || hashMatch) {
-                status.value = 'Skipping rolled-back patch $patchId';
-                print('[CP] SKIPPING rolled-back patch');
-                return false;
-              }
-              // Different patch — clear the old rollback marker.
-              rbFile.deleteSync();
-            } catch (e) {
-              // Corrupt marker — delete and continue.
-              print('[CP] rollback marker read error: $e');
-              try {
-                rbFile.deleteSync();
-              } catch (_) {}
-            }
-          }
-        }
+      // Skip a patch this device already rolled back, so a bad patch at
+      // 100% rollout can't crash-loop the device forever (rollback →
+      // refetch → re-crash). The marker persists across cold starts and
+      // works offline — no server round-trip needed. Cross-platform: on
+      // iOS the marker is written by the immediate/three-strike rollback;
+      // on Android it's promoted from the engine's rollback breadcrumb
+      // (see _reportPendingNativeRollback).
+      final quarantineDir = await _getPatchDir();
+      if (quarantineDir != null &&
+          _isPatchQuarantined(
+            patchDir: quarantineDir,
+            patchId: patchId,
+            patchHash: serverPatchHash,
+          )) {
+        status.value = 'Skipping rolled-back patch $patchId';
+        return false;
       }
 
       // ── Baseline compatibility guard ────────────────────────────
@@ -386,7 +360,8 @@ abstract final class CodePush {
           serverUrl: serverUrl,
           appId: appId,
           patchId: patchId,
-          reason: 'Engine has no code push support (stock Flutter engine '
+          reason:
+              'Engine has no code push support (stock Flutter engine '
               'or missing flutter/codepush method channel).',
           expectedFingerprint: expectedEngineFingerprint,
           actualFingerprint: null,
@@ -401,7 +376,8 @@ abstract final class CodePush {
       if (expectedEngineFingerprint != null &&
           actualEngineFingerprint != 'unknown' &&
           expectedEngineFingerprint != actualEngineFingerprint) {
-        status.value = 'Incompatible baseline: engine ABI mismatch '
+        status.value =
+            'Incompatible baseline: engine ABI mismatch '
             '($actualEngineFingerprint vs $expectedEngineFingerprint)';
         await _reportIncompatibleBaseline(
           serverUrl: serverUrl,
@@ -442,7 +418,8 @@ abstract final class CodePush {
             serverUrl: serverUrl,
             appId: appId,
             patchId: patchId,
-            reason: 'Baseline hash mismatch (soft gate — proceeding '
+            reason:
+                'Baseline hash mismatch (soft gate — proceeding '
                 'with download; engine ABI check is the hard gate)',
             expectedFingerprint: expectedBaselineHash,
             actualFingerprint: actualBaselineHash,
@@ -523,7 +500,8 @@ abstract final class CodePush {
                 'HEADER_MISMATCH patchId=$patchId payload=${payload.length}',
               );
             }
-            status.value = 'Patch format is unexpected — rolling back. '
+            status.value =
+                'Patch format is unexpected — rolling back. '
                 'Upgrade flutter_compile to the latest version and '
                 'rebuild the patch.';
             await _iosImmediateRollback(
@@ -615,6 +593,20 @@ abstract final class CodePush {
       } else {
         // Android/desktop: install via engine, restart required.
         await installPatch(patchBytes);
+        // Record this patch's server identity in a file the engine's
+        // rollback does NOT delete. If the patch crash-loops, the engine
+        // rolls it back pre-main and deletes patch_info.json before any
+        // Dart runs — so without this, the next launch couldn't learn
+        // which patch to quarantine. Promoted to the rollback marker by
+        // _reportPendingNativeRollback when the breadcrumb appears.
+        final patchDir = await _getPatchDir();
+        if (patchDir != null) {
+          _recordInstalledIdentity(
+            patchDir: patchDir,
+            patchId: patchId,
+            patchHash: serverPatchHash,
+          );
+        }
         status.value = 'Restart to apply';
         onUpdateReady?.call();
         return true;
@@ -699,8 +691,9 @@ abstract final class CodePush {
       final client = HttpClient();
       try {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
-        final req =
-            await client.postUrl(uri).timeout(const Duration(seconds: 5));
+        final req = await client
+            .postUrl(uri)
+            .timeout(const Duration(seconds: 5));
         req.headers.set('Content-Type', 'application/json; charset=utf-8');
         // Send encoded bytes, not a string: HttpClientRequest.write()
         // defaults to Latin-1, which throws on any non-Latin-1 character
@@ -745,6 +738,22 @@ abstract final class CodePush {
         return;
       }
 
+      // Quarantine the rolled-back patch BEFORE the (best-effort, maybe
+      // offline) telemetry POST, so the crash-loop breaks even with no
+      // network. Do it once per breadcrumb: a rollback_info.json that
+      // lingers offline must not later re-quarantine a good patch that
+      // was installed in the meantime.
+      if (info['quarantined'] != true) {
+        _promoteRolledBackIdentity(patchDir);
+        try {
+          info['quarantined'] = true;
+          marker.writeAsStringSync(jsonEncode(info));
+        } catch (_) {
+          // If we can't flag it, the identity file was already consumed
+          // by the promotion above, so a re-run finds nothing to promote.
+        }
+      }
+
       final payload = <String, dynamic>{
         'app_id': appId,
         'kind': 'auto_rollback',
@@ -759,8 +768,9 @@ abstract final class CodePush {
       final client = HttpClient();
       try {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
-        final req =
-            await client.postUrl(uri).timeout(const Duration(seconds: 5));
+        final req = await client
+            .postUrl(uri)
+            .timeout(const Duration(seconds: 5));
         req.headers.set('Content-Type', 'application/json; charset=utf-8');
         // Encoded bytes, not a string: write() defaults to Latin-1 and
         // throws on any non-Latin-1 character in the native-written
@@ -777,6 +787,89 @@ abstract final class CodePush {
       }
     } catch (_) {
       // Telemetry is best-effort. Never crash over it.
+    }
+  }
+
+  // ── Rolled-back-patch quarantine ──────────────────────────────────
+  //
+  // Breaks the "bad patch at 100% rollout crash-loops forever" failure:
+  // once a patch has been rolled back on this device, its server
+  // identity is recorded in `rolled_back_patch` and [checkAndInstall]
+  // refuses to re-download a patch that matches — offline, no server
+  // change needed. The marker holds `{patch_id, patch_hash}` and is
+  // cleared automatically once the server moves on to a different patch.
+
+  /// Whether [patchId]/[patchHash] matches the locally quarantined
+  /// rolled-back patch. Clears a stale marker when the server has moved
+  /// on to a different patch, so the quarantine is never permanent.
+  static bool _isPatchQuarantined({
+    required String patchDir,
+    required String? patchId,
+    required String? patchHash,
+  }) {
+    final rbFile = File('$patchDir/rolled_back_patch');
+    if (!rbFile.existsSync()) return false;
+    try {
+      final rb = jsonDecode(rbFile.readAsStringSync()) as Map<String, dynamic>;
+      final rbId = rb['patch_id']?.toString();
+      final rbHash = rb['patch_hash']?.toString();
+      final idMatch = rbId != null && rbId == patchId;
+      final hashMatch =
+          rbHash != null && patchHash != null && rbHash == patchHash;
+      if (idMatch || hashMatch) return true;
+      // Different patch — the previously-bad one is superseded; drop it.
+      rbFile.deleteSync();
+      return false;
+    } catch (_) {
+      // Corrupt marker — clear it and don't block this patch.
+      try {
+        rbFile.deleteSync();
+      } catch (_) {}
+      return false;
+    }
+  }
+
+  /// Records the just-installed patch's server identity in a file the
+  /// engine's rollback does not delete (Android), so a later launch can
+  /// quarantine it if the engine rolled it back. Best-effort.
+  static void _recordInstalledIdentity({
+    required String patchDir,
+    required String? patchId,
+    required String? patchHash,
+  }) {
+    try {
+      File('$patchDir/installed_patch_identity.json').writeAsStringSync(
+        jsonEncode(<String, Object?>{
+          'patch_id': patchId,
+          'patch_hash': patchHash,
+          'installed_at': DateTime.now().toIso8601String(),
+        }),
+      );
+    } catch (_) {
+      // Non-fatal: without it the crash-loop still bottoms out at the
+      // engine's three-strike rollback, just without the quarantine.
+    }
+  }
+
+  /// Promotes the surviving install-time identity into the
+  /// `rolled_back_patch` marker, then consumes the identity file. Called
+  /// when the engine's rollback breadcrumb is detected on Android.
+  static void _promoteRolledBackIdentity(String patchDir) {
+    try {
+      final idFile = File('$patchDir/installed_patch_identity.json');
+      if (!idFile.existsSync()) return;
+      final id = jsonDecode(idFile.readAsStringSync()) as Map<String, dynamic>;
+      File('$patchDir/rolled_back_patch').writeAsStringSync(
+        jsonEncode(<String, Object?>{
+          'patch_id': id['patch_id'],
+          'patch_hash': id['patch_hash'],
+          'rolled_back_at': DateTime.now().toIso8601String(),
+        }),
+      );
+      idFile.deleteSync();
+    } catch (_) {
+      // Best-effort quarantine; the three-strike rollback still protects
+      // the device even if this fails.
     }
   }
 
@@ -821,6 +914,35 @@ abstract final class CodePush {
     _reportedBaselineMismatches.clear();
     _cachedIsPlayInstall = null;
   }
+
+  /// Test-only wrappers for the rolled-back-patch quarantine helpers.
+  @visibleForTesting
+  static bool debugIsPatchQuarantined({
+    required String patchDir,
+    required String? patchId,
+    required String? patchHash,
+  }) =>
+      _isPatchQuarantined(
+        patchDir: patchDir,
+        patchId: patchId,
+        patchHash: patchHash,
+      );
+
+  @visibleForTesting
+  static void debugRecordInstalledIdentity({
+    required String patchDir,
+    required String? patchId,
+    required String? patchHash,
+  }) =>
+      _recordInstalledIdentity(
+        patchDir: patchDir,
+        patchId: patchId,
+        patchHash: patchHash,
+      );
+
+  @visibleForTesting
+  static void debugPromoteRolledBackIdentity(String patchDir) =>
+      _promoteRolledBackIdentity(patchDir);
 
   /// Cached distribution-proof baseline UUID (see [_readBaselineId]).
   static String? _cachedBaselineId;
@@ -908,11 +1030,12 @@ abstract final class CodePush {
         DateTime.now().difference(failedAt) < _baselineHashRetryAfter) {
       return Future.value(null);
     }
-    return _baselineHashInFlight ??=
-        _computeBaselineHashUncached().then((hash) {
-      if (hash == null) _baselineHashFailedAt = DateTime.now();
-      return hash;
-    }).whenComplete(() => _baselineHashInFlight = null);
+    return _baselineHashInFlight ??= _computeBaselineHashUncached()
+        .then((hash) {
+          if (hash == null) _baselineHashFailedAt = DateTime.now();
+          return hash;
+        })
+        .whenComplete(() => _baselineHashInFlight = null);
   }
 
   static Future<String?> _computeBaselineHashUncached() async {
@@ -1439,7 +1562,8 @@ class CodePushOverlay extends StatefulWidget {
     BuildContext context,
     VoidCallback onRestart,
     VoidCallback onDismiss,
-  )? bannerBuilder;
+  )?
+  bannerBuilder;
 
   /// Whether to show the debug status bar at the top. Defaults to false.
   final bool showDebugBar;
@@ -1639,7 +1763,7 @@ class CodePushPatchBuilder extends StatelessWidget {
 
   /// Builder called with the patch data string (or null if no patch).
   final Widget Function(BuildContext context, String? patchData, Widget? child)
-      builder;
+  builder;
 
   /// Optional child widget passed to the builder (typically the default/baseline UI).
   final Widget? child;

--- a/test/rollback_quarantine_test.dart
+++ b/test/rollback_quarantine_test.dart
@@ -191,6 +191,21 @@ void main() {
       expect(marker().existsSync(), isFalse);
     });
 
+    test('a corrupt breadcrumb neither promotes nor consumes the identity', () {
+      breadcrumb().writeAsStringSync('{ not valid json');
+      CodePush.debugRecordInstalledIdentity(
+        patchDir: patchDir.path,
+        patchId: 'good',
+        patchHash: 'h',
+      );
+
+      CodePush.debugQuarantineFromBreadcrumb(patchDir.path);
+
+      // No quarantine written, and the identity is left intact.
+      expect(marker().existsSync(), isFalse);
+      expect(identity().existsSync(), isTrue);
+    });
+
     test('end-to-end: install bad → rollback → the bad patch is quarantined',
         () {
       // Install records identity.

--- a/test/rollback_quarantine_test.dart
+++ b/test/rollback_quarantine_test.dart
@@ -121,6 +121,75 @@ void main() {
       CodePush.debugPromoteRolledBackIdentity(patchDir.path);
       expect(marker().existsSync(), isFalse);
     });
+  });
+
+  group('_quarantineFromBreadcrumb (once-per-breadcrumb guard)', () {
+    File breadcrumb() => File('${patchDir.path}/rollback_info.json');
+
+    void writeBreadcrumb({bool quarantined = false}) {
+      breadcrumb().writeAsStringSync(jsonEncode({
+        'reason': 'boot_loop',
+        'patch_version': '1.0.0+2',
+        if (quarantined) 'quarantined': true,
+      }));
+    }
+
+    test('a fresh breadcrumb promotes the identity and flags itself', () {
+      CodePush.debugRecordInstalledIdentity(
+        patchDir: patchDir.path,
+        patchId: 'bad',
+        patchHash: 'h',
+      );
+      writeBreadcrumb();
+
+      CodePush.debugQuarantineFromBreadcrumb(patchDir.path);
+
+      expect(
+        CodePush.debugIsPatchQuarantined(
+          patchDir: patchDir.path,
+          patchId: 'bad',
+          patchHash: null,
+        ),
+        isTrue,
+      );
+      final bc =
+          jsonDecode(breadcrumb().readAsStringSync()) as Map<String, dynamic>;
+      expect(bc['quarantined'], isTrue);
+      expect(identity().existsSync(), isFalse); // consumed
+    });
+
+    test(
+        'a breadcrumb already flagged does NOT re-quarantine a good patch '
+        'installed in the meantime', () {
+      // The bad patch was already quarantined; its breadcrumb lingers
+      // (telemetry never acked, device offline).
+      writeBreadcrumb(quarantined: true);
+      // Meanwhile a genuinely good patch got installed.
+      CodePush.debugRecordInstalledIdentity(
+        patchDir: patchDir.path,
+        patchId: 'good',
+        patchHash: 'goodhash',
+      );
+
+      CodePush.debugQuarantineFromBreadcrumb(patchDir.path);
+
+      // The good patch must NOT be quarantined by the stale breadcrumb.
+      expect(
+        CodePush.debugIsPatchQuarantined(
+          patchDir: patchDir.path,
+          patchId: 'good',
+          patchHash: 'goodhash',
+        ),
+        isFalse,
+      );
+      // The good identity is untouched (not consumed).
+      expect(identity().existsSync(), isTrue);
+    });
+
+    test('no breadcrumb → safe no-op', () {
+      CodePush.debugQuarantineFromBreadcrumb(patchDir.path);
+      expect(marker().existsSync(), isFalse);
+    });
 
     test('end-to-end: install bad → rollback → the bad patch is quarantined',
         () {

--- a/test/rollback_quarantine_test.dart
+++ b/test/rollback_quarantine_test.dart
@@ -1,0 +1,155 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterplaza_code_push/flutterplaza_code_push.dart';
+
+/// Finding #7: once a patch has been rolled back on this device, the SDK
+/// must refuse to re-download it (offline, no server round-trip), so a
+/// bad patch at 100% rollout can't crash-loop the device forever.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory patchDir;
+  File marker() => File('${patchDir.path}/rolled_back_patch');
+  File identity() => File('${patchDir.path}/installed_patch_identity.json');
+
+  setUp(() {
+    patchDir = Directory.systemTemp.createTempSync('quarantine_test');
+  });
+  tearDown(() => patchDir.deleteSync(recursive: true));
+
+  group('_isPatchQuarantined', () {
+    void writeMarker({String? id, String? hash}) {
+      marker().writeAsStringSync(jsonEncode({
+        if (id != null) 'patch_id': id,
+        if (hash != null) 'patch_hash': hash,
+      }));
+    }
+
+    test('no marker → not quarantined', () {
+      expect(
+        CodePush.debugIsPatchQuarantined(
+          patchDir: patchDir.path,
+          patchId: 'p1',
+          patchHash: 'h1',
+        ),
+        isFalse,
+      );
+    });
+
+    test('matches by patch_id', () {
+      writeMarker(id: 'bad');
+      expect(
+        CodePush.debugIsPatchQuarantined(
+          patchDir: patchDir.path,
+          patchId: 'bad',
+          patchHash: 'whatever',
+        ),
+        isTrue,
+      );
+    });
+
+    test('matches by patch_hash', () {
+      writeMarker(hash: 'deadbeef');
+      expect(
+        CodePush.debugIsPatchQuarantined(
+          patchDir: patchDir.path,
+          patchId: 'different-id',
+          patchHash: 'deadbeef',
+        ),
+        isTrue,
+      );
+    });
+
+    test('a different patch is not quarantined AND clears the stale marker',
+        () {
+      writeMarker(id: 'bad', hash: 'oldhash');
+      expect(
+        CodePush.debugIsPatchQuarantined(
+          patchDir: patchDir.path,
+          patchId: 'newgood',
+          patchHash: 'newhash',
+        ),
+        isFalse,
+      );
+      // The quarantine is never permanent: once the server moves on, the
+      // marker is dropped.
+      expect(marker().existsSync(), isFalse);
+    });
+
+    test('a corrupt marker is cleared and does not block', () {
+      marker().writeAsStringSync('{ not json');
+      expect(
+        CodePush.debugIsPatchQuarantined(
+          patchDir: patchDir.path,
+          patchId: 'p1',
+          patchHash: 'h1',
+        ),
+        isFalse,
+      );
+      expect(marker().existsSync(), isFalse);
+    });
+  });
+
+  group('Android promotion (install identity → rollback marker)', () {
+    test('promotes the surviving identity and consumes it', () {
+      CodePush.debugRecordInstalledIdentity(
+        patchDir: patchDir.path,
+        patchId: 'bad',
+        patchHash: 'badhash',
+      );
+      expect(identity().existsSync(), isTrue);
+
+      CodePush.debugPromoteRolledBackIdentity(patchDir.path);
+
+      // The identity is now the quarantine marker...
+      expect(
+        CodePush.debugIsPatchQuarantined(
+          patchDir: patchDir.path,
+          patchId: 'bad',
+          patchHash: null,
+        ),
+        isTrue,
+      );
+      // ...and the identity file is consumed, so a persisting rollback
+      // breadcrumb can't re-promote a later good patch's identity.
+      expect(identity().existsSync(), isFalse);
+    });
+
+    test('promotion with no identity file is a safe no-op', () {
+      CodePush.debugPromoteRolledBackIdentity(patchDir.path);
+      expect(marker().existsSync(), isFalse);
+    });
+
+    test('end-to-end: install bad → rollback → the bad patch is quarantined',
+        () {
+      // Install records identity.
+      CodePush.debugRecordInstalledIdentity(
+        patchDir: patchDir.path,
+        patchId: 'p-bad',
+        patchHash: 'h-bad',
+      );
+      // Engine rolls it back → SDK promotes the identity.
+      CodePush.debugPromoteRolledBackIdentity(patchDir.path);
+      // A later check offering the same patch is refused.
+      expect(
+        CodePush.debugIsPatchQuarantined(
+          patchDir: patchDir.path,
+          patchId: 'p-bad',
+          patchHash: 'h-bad',
+        ),
+        isTrue,
+      );
+      // But a genuinely new patch is allowed (and clears the quarantine).
+      expect(
+        CodePush.debugIsPatchQuarantined(
+          patchDir: patchDir.path,
+          patchId: 'p-good',
+          patchHash: 'h-good',
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What
Fixes Gate-2 **finding #7**: after a bad patch auto-rolls-back, `checkAndInstall` re-fetched the **same** patch (still at 100% rollout) → re-crash → rollback → refetch, an unbounded loop — a fleet DoS until someone manually deactivates the patch.

## Why Android was exposed
iOS already skipped a rolled-back patch via the `rolled_back_patch` marker, but:
- the quarantine check was gated on `Platform.isIOS`, and
- on Android the engine rolls back **pre-main** and deletes `patch_info.json` before any Dart runs, so there was **no surviving record** of the server `patch_id`/`patch_hash` to quarantine.

## Change (SDK-only)
- **Cross-platform skip**: `checkAndInstall` drops the `isIOS` gate — a patch whose server `patch_id`/`patch_hash` matches the local `rolled_back_patch` marker is refused, **offline**, no server round-trip. The marker clears automatically once the server offers a different patch, so a quarantine is never permanent.
- **Surviving identity (Android)**: install writes `installed_patch_identity.json`, a file the engine's rollback doesn't delete, so the identity outlives the pre-main rollback.
- **Promotion**: on detecting the engine's rollback breadcrumb, `_reportPendingNativeRollback` promotes that identity into the marker **before** the best-effort telemetry POST (so the loop breaks even with no network), and only **once per breadcrumb** — a rollback breadcrumb that lingers offline can't later re-quarantine a good patch that was installed in the meantime.

## Relationship to the kill switch
The server kill switch (already shipped) is the **operator** lever for a fleet-wide stop. This makes each **device self-heal** on its own, before anyone intervenes.

## Tests
8 new (`rollback_quarantine_test.dart`): id/hash match, stale-marker clearing, corrupt-marker safety, the install→rollback→quarantine promotion, and identity consumption. 80 total pass, analyze clean.

## Device note (your side)
The A4 crash-protection proof already showed the three-strike rollback firing; this adds the quarantine on top. A device re-test: install a deliberately-bad patch at 100%, confirm it rolls back **and then is not re-offered** (logcat shows the skip), where before it would re-download and re-crash.