### PR TITLE
Stop re-offering an already-installed patch; send device_hash (findings #6, #11)

### DIFF
--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -283,8 +283,7 @@ abstract final class CodePush {
       final deviceBaselineHash = await _computeBaselineHash();
       final deviceBaselineId = await _readBaselineId();
       final deviceHash = await _deviceHash();
-      final url =
-          '$serverUrl/api/v1/updates'
+      final url = '$serverUrl/api/v1/updates'
           '?app_id=$appId'
           '&version=${Uri.encodeComponent(releaseVersion)}'
           '&platform=$_platform'
@@ -390,8 +389,7 @@ abstract final class CodePush {
           serverUrl: serverUrl,
           appId: appId,
           patchId: patchId,
-          reason:
-              'Engine has no code push support (stock Flutter engine '
+          reason: 'Engine has no code push support (stock Flutter engine '
               'or missing flutter/codepush method channel).',
           expectedFingerprint: expectedEngineFingerprint,
           actualFingerprint: null,
@@ -406,8 +404,7 @@ abstract final class CodePush {
       if (expectedEngineFingerprint != null &&
           actualEngineFingerprint != 'unknown' &&
           expectedEngineFingerprint != actualEngineFingerprint) {
-        status.value =
-            'Incompatible baseline: engine ABI mismatch '
+        status.value = 'Incompatible baseline: engine ABI mismatch '
             '($actualEngineFingerprint vs $expectedEngineFingerprint)';
         await _reportIncompatibleBaseline(
           serverUrl: serverUrl,
@@ -448,8 +445,7 @@ abstract final class CodePush {
             serverUrl: serverUrl,
             appId: appId,
             patchId: patchId,
-            reason:
-                'Baseline hash mismatch (soft gate — proceeding '
+            reason: 'Baseline hash mismatch (soft gate — proceeding '
                 'with download; engine ABI check is the hard gate)',
             expectedFingerprint: expectedBaselineHash,
             actualFingerprint: actualBaselineHash,
@@ -530,8 +526,7 @@ abstract final class CodePush {
                 'HEADER_MISMATCH patchId=$patchId payload=${payload.length}',
               );
             }
-            status.value =
-                'Patch format is unexpected — rolling back. '
+            status.value = 'Patch format is unexpected — rolling back. '
                 'Upgrade flutter_compile to the latest version and '
                 'rebuild the patch.';
             await _iosImmediateRollback(
@@ -721,9 +716,8 @@ abstract final class CodePush {
       final client = HttpClient();
       try {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
-        final req = await client
-            .postUrl(uri)
-            .timeout(const Duration(seconds: 5));
+        final req =
+            await client.postUrl(uri).timeout(const Duration(seconds: 5));
         req.headers.set('Content-Type', 'application/json; charset=utf-8');
         // Send encoded bytes, not a string: HttpClientRequest.write()
         // defaults to Latin-1, which throws on any non-Latin-1 character
@@ -787,9 +781,8 @@ abstract final class CodePush {
       final client = HttpClient();
       try {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
-        final req = await client
-            .postUrl(uri)
-            .timeout(const Duration(seconds: 5));
+        final req =
+            await client.postUrl(uri).timeout(const Duration(seconds: 5));
         req.headers.set('Content-Type', 'application/json; charset=utf-8');
         // Encoded bytes, not a string: write() defaults to Latin-1 and
         // throws on any non-Latin-1 character in the native-written
@@ -863,11 +856,17 @@ abstract final class CodePush {
   /// (written on Android install, surviving the restart). Does NOT clear
   /// the file on mismatch: a different offer is a genuinely new patch to
   /// install, which will overwrite the identity anyway.
+  ///
+  /// Gated on the patch bytes still being present: EVERY rollback path
+  /// (crash three-strike, the OTA kill switch, or a public `rollback()`)
+  /// removes the patch file, so a surviving-but-stale identity must not
+  /// block re-delivery of the same patch after it was reverted.
   static bool _isPatchAlreadyInstalled({
     required String patchDir,
     required String? patchId,
     required String? patchHash,
   }) {
+    if (!File('$patchDir/$_patchFilename').existsSync()) return false;
     final f = File('$patchDir/installed_patch_identity.json');
     if (!f.existsSync()) return false;
     try {
@@ -885,21 +884,25 @@ abstract final class CodePush {
   /// limit and bucket staged rollout (`device_hash % 100`). Best-effort:
   /// returns null when it can't be read/created, which simply leaves the
   /// param off — the server then skips the limiter, exactly as before.
+  static String? _cachedDeviceHash;
+
   static Future<String?> _deviceHash() async {
+    final cached = _cachedDeviceHash;
+    if (cached != null) return cached;
     try {
       final patchDir = await _getPatchDir();
       if (patchDir == null) return null;
       final f = File('$patchDir/device_id');
       if (f.existsSync()) {
         final v = f.readAsStringSync().trim();
-        if (v.isNotEmpty) return v;
+        if (v.isNotEmpty) return _cachedDeviceHash = v;
       }
       final rng = Random.secure();
       // A positive 63-bit int (two draws), as a decimal string.
       final id = (rng.nextInt(0x80000000) << 32) | rng.nextInt(0x100000000);
       Directory(patchDir).createSync(recursive: true);
       f.writeAsStringSync('$id');
-      return '$id';
+      return _cachedDeviceHash = '$id';
     } catch (_) {
       return null;
     }
@@ -1024,6 +1027,8 @@ abstract final class CodePush {
     _baselineHashInFlight = null;
     _reportedBaselineMismatches.clear();
     _cachedIsPlayInstall = null;
+    _cachedDeviceHash = null;
+    _cachedPatchDir = null;
   }
 
   /// Test-only wrappers for the rolled-back-patch quarantine helpers.
@@ -1032,22 +1037,24 @@ abstract final class CodePush {
     required String patchDir,
     required String? patchId,
     required String? patchHash,
-  }) => _isPatchQuarantined(
-    patchDir: patchDir,
-    patchId: patchId,
-    patchHash: patchHash,
-  );
+  }) =>
+      _isPatchQuarantined(
+        patchDir: patchDir,
+        patchId: patchId,
+        patchHash: patchHash,
+      );
 
   @visibleForTesting
   static void debugRecordInstalledIdentity({
     required String patchDir,
     required String? patchId,
     required String? patchHash,
-  }) => _recordInstalledIdentity(
-    patchDir: patchDir,
-    patchId: patchId,
-    patchHash: patchHash,
-  );
+  }) =>
+      _recordInstalledIdentity(
+        patchDir: patchDir,
+        patchId: patchId,
+        patchHash: patchHash,
+      );
 
   @visibleForTesting
   static void debugPromoteRolledBackIdentity(String patchDir) =>
@@ -1062,11 +1069,12 @@ abstract final class CodePush {
     required String patchDir,
     required String? patchId,
     required String? patchHash,
-  }) => _isPatchAlreadyInstalled(
-    patchDir: patchDir,
-    patchId: patchId,
-    patchHash: patchHash,
-  );
+  }) =>
+      _isPatchAlreadyInstalled(
+        patchDir: patchDir,
+        patchId: patchId,
+        patchHash: patchHash,
+      );
 
   @visibleForTesting
   static Future<String?> debugDeviceHash() => _deviceHash();
@@ -1157,12 +1165,11 @@ abstract final class CodePush {
         DateTime.now().difference(failedAt) < _baselineHashRetryAfter) {
       return Future.value(null);
     }
-    return _baselineHashInFlight ??= _computeBaselineHashUncached()
-        .then((hash) {
-          if (hash == null) _baselineHashFailedAt = DateTime.now();
-          return hash;
-        })
-        .whenComplete(() => _baselineHashInFlight = null);
+    return _baselineHashInFlight ??=
+        _computeBaselineHashUncached().then((hash) {
+      if (hash == null) _baselineHashFailedAt = DateTime.now();
+      return hash;
+    }).whenComplete(() => _baselineHashInFlight = null);
   }
 
   static Future<String?> _computeBaselineHashUncached() async {
@@ -1689,8 +1696,7 @@ class CodePushOverlay extends StatefulWidget {
     BuildContext context,
     VoidCallback onRestart,
     VoidCallback onDismiss,
-  )?
-  bannerBuilder;
+  )? bannerBuilder;
 
   /// Whether to show the debug status bar at the top. Defaults to false.
   final bool showDebugBar;
@@ -1890,7 +1896,7 @@ class CodePushPatchBuilder extends StatelessWidget {
 
   /// Builder called with the patch data string (or null if no patch).
   final Widget Function(BuildContext context, String? patchData, Widget? child)
-  builder;
+      builder;
 
   /// Optional child widget passed to the builder (typically the default/baseline UI).
   final Widget? child;

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show Timer, unawaited;
 import 'dart:convert' show base64Encode, jsonDecode, jsonEncode, utf8;
 import 'dart:io' show Directory, File, FileMode, HttpClient, Platform, exit;
+import 'dart:math' show Random;
 
 import 'dart:ui' as ui;
 
@@ -281,13 +282,16 @@ abstract final class CodePush {
       // (further down) still protects us.
       final deviceBaselineHash = await _computeBaselineHash();
       final deviceBaselineId = await _readBaselineId();
-      final url = '$serverUrl/api/v1/updates'
+      final deviceHash = await _deviceHash();
+      final url =
+          '$serverUrl/api/v1/updates'
           '?app_id=$appId'
           '&version=${Uri.encodeComponent(releaseVersion)}'
           '&platform=$_platform'
           '&channel=$channel'
           '${deviceBaselineHash != null ? '&baseline_hash=$deviceBaselineHash' : ''}'
-          '${deviceBaselineId != null ? '&baseline_id=$deviceBaselineId' : ''}';
+          '${deviceBaselineId != null ? '&baseline_id=$deviceBaselineId' : ''}'
+          '${deviceHash != null ? '&device_hash=$deviceHash' : ''}';
 
       final r = await _httpGet(url);
       if (r.statusCode == 204 || r.statusCode != 200) {
@@ -349,6 +353,24 @@ abstract final class CodePush {
         return false;
       }
 
+      // Don't re-offer a patch this device already installed. On Android
+      // a patch applies on the next cold boot, so without this the server
+      // keeps offering the same patch every launch and the SDK
+      // re-downloads it and re-fires "restart to apply" forever. The
+      // install-time identity (finding #7's `installed_patch_identity.json`)
+      // survives the restart, so a matching offer means "already applied".
+      // (iOS latches `_moduleLoaded` and never writes this file, so this
+      // is effectively the Android equivalent of that latch.)
+      if (quarantineDir != null &&
+          _isPatchAlreadyInstalled(
+            patchDir: quarantineDir,
+            patchId: patchId,
+            patchHash: serverPatchHash,
+          )) {
+        status.value = 'Patch already installed';
+        return false;
+      }
+
       // ── Baseline compatibility guard ────────────────────────────
       //
       // Before touching any bytes, verify that the running Flutter
@@ -368,7 +390,8 @@ abstract final class CodePush {
           serverUrl: serverUrl,
           appId: appId,
           patchId: patchId,
-          reason: 'Engine has no code push support (stock Flutter engine '
+          reason:
+              'Engine has no code push support (stock Flutter engine '
               'or missing flutter/codepush method channel).',
           expectedFingerprint: expectedEngineFingerprint,
           actualFingerprint: null,
@@ -383,7 +406,8 @@ abstract final class CodePush {
       if (expectedEngineFingerprint != null &&
           actualEngineFingerprint != 'unknown' &&
           expectedEngineFingerprint != actualEngineFingerprint) {
-        status.value = 'Incompatible baseline: engine ABI mismatch '
+        status.value =
+            'Incompatible baseline: engine ABI mismatch '
             '($actualEngineFingerprint vs $expectedEngineFingerprint)';
         await _reportIncompatibleBaseline(
           serverUrl: serverUrl,
@@ -424,7 +448,8 @@ abstract final class CodePush {
             serverUrl: serverUrl,
             appId: appId,
             patchId: patchId,
-            reason: 'Baseline hash mismatch (soft gate — proceeding '
+            reason:
+                'Baseline hash mismatch (soft gate — proceeding '
                 'with download; engine ABI check is the hard gate)',
             expectedFingerprint: expectedBaselineHash,
             actualFingerprint: actualBaselineHash,
@@ -505,7 +530,8 @@ abstract final class CodePush {
                 'HEADER_MISMATCH patchId=$patchId payload=${payload.length}',
               );
             }
-            status.value = 'Patch format is unexpected — rolling back. '
+            status.value =
+                'Patch format is unexpected — rolling back. '
                 'Upgrade flutter_compile to the latest version and '
                 'rebuild the patch.';
             await _iosImmediateRollback(
@@ -695,8 +721,9 @@ abstract final class CodePush {
       final client = HttpClient();
       try {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
-        final req =
-            await client.postUrl(uri).timeout(const Duration(seconds: 5));
+        final req = await client
+            .postUrl(uri)
+            .timeout(const Duration(seconds: 5));
         req.headers.set('Content-Type', 'application/json; charset=utf-8');
         // Send encoded bytes, not a string: HttpClientRequest.write()
         // defaults to Latin-1, which throws on any non-Latin-1 character
@@ -760,8 +787,9 @@ abstract final class CodePush {
       final client = HttpClient();
       try {
         final uri = Uri.parse('$serverUrl/api/v1/telemetry/client-error');
-        final req =
-            await client.postUrl(uri).timeout(const Duration(seconds: 5));
+        final req = await client
+            .postUrl(uri)
+            .timeout(const Duration(seconds: 5));
         req.headers.set('Content-Type', 'application/json; charset=utf-8');
         // Encoded bytes, not a string: write() defaults to Latin-1 and
         // throws on any non-Latin-1 character in the native-written
@@ -790,6 +818,21 @@ abstract final class CodePush {
   // change needed. The marker holds `{patch_id, patch_hash}` and is
   // cleared automatically once the server moves on to a different patch.
 
+  /// Whether a stored `{patch_id, patch_hash}` identity matches the
+  /// server's offer (by id OR hash). Shared by the quarantine and
+  /// already-installed checks.
+  static bool _identityMatches(
+    Map<String, dynamic> stored,
+    String? patchId,
+    String? patchHash,
+  ) {
+    final sId = stored['patch_id']?.toString();
+    final sHash = stored['patch_hash']?.toString();
+    final idMatch = sId != null && sId == patchId;
+    final hashMatch = sHash != null && patchHash != null && sHash == patchHash;
+    return idMatch || hashMatch;
+  }
+
   /// Whether [patchId]/[patchHash] matches the locally quarantined
   /// rolled-back patch. Clears a stale marker when the server has moved
   /// on to a different patch, so the quarantine is never permanent.
@@ -802,12 +845,7 @@ abstract final class CodePush {
     if (!rbFile.existsSync()) return false;
     try {
       final rb = jsonDecode(rbFile.readAsStringSync()) as Map<String, dynamic>;
-      final rbId = rb['patch_id']?.toString();
-      final rbHash = rb['patch_hash']?.toString();
-      final idMatch = rbId != null && rbId == patchId;
-      final hashMatch =
-          rbHash != null && patchHash != null && rbHash == patchHash;
-      if (idMatch || hashMatch) return true;
+      if (_identityMatches(rb, patchId, patchHash)) return true;
       // Different patch — the previously-bad one is superseded; drop it.
       rbFile.deleteSync();
       return false;
@@ -817,6 +855,53 @@ abstract final class CodePush {
         rbFile.deleteSync();
       } catch (_) {}
       return false;
+    }
+  }
+
+  /// Whether the server-offered [patchId]/[patchHash] is the patch this
+  /// device already installed — read from `installed_patch_identity.json`
+  /// (written on Android install, surviving the restart). Does NOT clear
+  /// the file on mismatch: a different offer is a genuinely new patch to
+  /// install, which will overwrite the identity anyway.
+  static bool _isPatchAlreadyInstalled({
+    required String patchDir,
+    required String? patchId,
+    required String? patchHash,
+  }) {
+    final f = File('$patchDir/installed_patch_identity.json');
+    if (!f.existsSync()) return false;
+    try {
+      final stored = jsonDecode(f.readAsStringSync()) as Map<String, dynamic>;
+      return _identityMatches(stored, patchId, patchHash);
+    } catch (_) {
+      // Corrupt — don't block a fresh install.
+      return false;
+    }
+  }
+
+  /// A stable, numeric per-install identifier for the `device_hash`
+  /// query param. Persisted to the patch dir so it survives restarts;
+  /// numeric so the server can both key its 15-minute per-device rate
+  /// limit and bucket staged rollout (`device_hash % 100`). Best-effort:
+  /// returns null when it can't be read/created, which simply leaves the
+  /// param off — the server then skips the limiter, exactly as before.
+  static Future<String?> _deviceHash() async {
+    try {
+      final patchDir = await _getPatchDir();
+      if (patchDir == null) return null;
+      final f = File('$patchDir/device_id');
+      if (f.existsSync()) {
+        final v = f.readAsStringSync().trim();
+        if (v.isNotEmpty) return v;
+      }
+      final rng = Random.secure();
+      // A positive 63-bit int (two draws), as a decimal string.
+      final id = (rng.nextInt(0x80000000) << 32) | rng.nextInt(0x100000000);
+      Directory(patchDir).createSync(recursive: true);
+      f.writeAsStringSync('$id');
+      return '$id';
+    } catch (_) {
+      return null;
     }
   }
 
@@ -947,24 +1032,22 @@ abstract final class CodePush {
     required String patchDir,
     required String? patchId,
     required String? patchHash,
-  }) =>
-      _isPatchQuarantined(
-        patchDir: patchDir,
-        patchId: patchId,
-        patchHash: patchHash,
-      );
+  }) => _isPatchQuarantined(
+    patchDir: patchDir,
+    patchId: patchId,
+    patchHash: patchHash,
+  );
 
   @visibleForTesting
   static void debugRecordInstalledIdentity({
     required String patchDir,
     required String? patchId,
     required String? patchHash,
-  }) =>
-      _recordInstalledIdentity(
-        patchDir: patchDir,
-        patchId: patchId,
-        patchHash: patchHash,
-      );
+  }) => _recordInstalledIdentity(
+    patchDir: patchDir,
+    patchId: patchId,
+    patchHash: patchHash,
+  );
 
   @visibleForTesting
   static void debugPromoteRolledBackIdentity(String patchDir) =>
@@ -973,6 +1056,20 @@ abstract final class CodePush {
   @visibleForTesting
   static void debugQuarantineFromBreadcrumb(String patchDir) =>
       _quarantineFromBreadcrumb(patchDir);
+
+  @visibleForTesting
+  static bool debugIsPatchAlreadyInstalled({
+    required String patchDir,
+    required String? patchId,
+    required String? patchHash,
+  }) => _isPatchAlreadyInstalled(
+    patchDir: patchDir,
+    patchId: patchId,
+    patchHash: patchHash,
+  );
+
+  @visibleForTesting
+  static Future<String?> debugDeviceHash() => _deviceHash();
 
   /// Cached distribution-proof baseline UUID (see [_readBaselineId]).
   static String? _cachedBaselineId;
@@ -1060,11 +1157,12 @@ abstract final class CodePush {
         DateTime.now().difference(failedAt) < _baselineHashRetryAfter) {
       return Future.value(null);
     }
-    return _baselineHashInFlight ??=
-        _computeBaselineHashUncached().then((hash) {
-      if (hash == null) _baselineHashFailedAt = DateTime.now();
-      return hash;
-    }).whenComplete(() => _baselineHashInFlight = null);
+    return _baselineHashInFlight ??= _computeBaselineHashUncached()
+        .then((hash) {
+          if (hash == null) _baselineHashFailedAt = DateTime.now();
+          return hash;
+        })
+        .whenComplete(() => _baselineHashInFlight = null);
   }
 
   static Future<String?> _computeBaselineHashUncached() async {
@@ -1591,7 +1689,8 @@ class CodePushOverlay extends StatefulWidget {
     BuildContext context,
     VoidCallback onRestart,
     VoidCallback onDismiss,
-  )? bannerBuilder;
+  )?
+  bannerBuilder;
 
   /// Whether to show the debug status bar at the top. Defaults to false.
   final bool showDebugBar;
@@ -1791,7 +1890,7 @@ class CodePushPatchBuilder extends StatelessWidget {
 
   /// Builder called with the patch data string (or null if no patch).
   final Widget Function(BuildContext context, String? patchData, Widget? child)
-      builder;
+  builder;
 
   /// Optional child widget passed to the builder (typically the default/baseline UI).
   final Widget? child;

--- a/test/reoffer_and_devicehash_test.dart
+++ b/test/reoffer_and_devicehash_test.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterplaza_code_push/flutterplaza_code_push.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  HttpOverrides.global = null;
+
+  const engineChannel = MethodChannel('flutter/codepush', JSONMethodCodec());
+
+  // ── Finding #6: already-installed skip ──────────────────────────────
+  group('_isPatchAlreadyInstalled', () {
+    late Directory patchDir;
+    File identity() => File('${patchDir.path}/installed_patch_identity.json');
+
+    setUp(() => patchDir = Directory.systemTemp.createTempSync('reoffer'));
+    tearDown(() => patchDir.deleteSync(recursive: true));
+
+    void writeIdentity({String? id, String? hash}) {
+      identity().writeAsStringSync(jsonEncode({
+        if (id != null) 'patch_id': id,
+        if (hash != null) 'patch_hash': hash,
+      }));
+    }
+
+    test('no identity file → not already installed', () {
+      expect(
+        CodePush.debugIsPatchAlreadyInstalled(
+          patchDir: patchDir.path,
+          patchId: 'p1',
+          patchHash: 'h1',
+        ),
+        isFalse,
+      );
+    });
+
+    test('matches the installed patch by id (would skip re-offer)', () {
+      writeIdentity(id: 'installed');
+      expect(
+        CodePush.debugIsPatchAlreadyInstalled(
+          patchDir: patchDir.path,
+          patchId: 'installed',
+          patchHash: 'anything',
+        ),
+        isTrue,
+      );
+    });
+
+    test('a genuinely new patch is not "already installed", file kept', () {
+      writeIdentity(id: 'old', hash: 'oldhash');
+      expect(
+        CodePush.debugIsPatchAlreadyInstalled(
+          patchDir: patchDir.path,
+          patchId: 'new',
+          patchHash: 'newhash',
+        ),
+        isFalse,
+      );
+      // Unlike the quarantine check, a mismatch does NOT delete the
+      // identity — the new patch's install will overwrite it.
+      expect(identity().existsSync(), isTrue);
+    });
+
+    test('corrupt identity does not block a fresh install', () {
+      identity().writeAsStringSync('{ nope');
+      expect(
+        CodePush.debugIsPatchAlreadyInstalled(
+          patchDir: patchDir.path,
+          patchId: 'p1',
+          patchHash: 'h1',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  // ── Finding #11: device_hash ────────────────────────────────────────
+  group('device_hash', () {
+    late Directory patchDir;
+    late HttpServer server;
+    late List<Uri> requests;
+
+    setUp(() async {
+      patchDir = Directory.systemTemp.createTempSync('devicehash');
+      requests = <Uri>[];
+      CodePush.debugResetBaselineHashCache();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(engineChannel, (MethodCall call) async {
+        if (call.method == 'CodePush.getPatchDir') return patchDir.path;
+        if (call.method == 'CodePush.getEngineAbi') return 'abi';
+        return null;
+      });
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((HttpRequest req) {
+        requests.add(req.uri);
+        req.response.statusCode = HttpStatus.noContent;
+        req.response.close();
+      });
+    });
+
+    tearDown(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(engineChannel, null);
+      CodePush.debugResetBaselineHashCache();
+      await server.close(force: true);
+      patchDir.deleteSync(recursive: true);
+    });
+
+    test('generates a stable numeric id, persisted to the patch dir', () async {
+      final first = await CodePush.debugDeviceHash();
+      final second = await CodePush.debugDeviceHash();
+
+      expect(first, isNotNull);
+      expect(int.tryParse(first!), isNotNull, reason: 'must be numeric');
+      expect(int.parse(first), greaterThan(0));
+      expect(second, equals(first), reason: 'stable across calls');
+      expect(File('${patchDir.path}/device_id').existsSync(), isTrue);
+    });
+
+    test('checkAndInstall sends device_hash on the /updates query', () async {
+      await CodePush.checkAndInstall(
+        serverUrl: 'http://127.0.0.1:${server.port}',
+        appId: 'app',
+        releaseVersion: '1.0.0+1',
+      );
+
+      expect(requests, hasLength(1));
+      final dh = requests.single.queryParameters['device_hash'];
+      expect(dh, isNotNull);
+      expect(int.tryParse(dh!), isNotNull);
+    });
+  });
+}

--- a/test/reoffer_and_devicehash_test.dart
+++ b/test/reoffer_and_devicehash_test.dart
@@ -15,11 +15,15 @@ void main() {
   group('_isPatchAlreadyInstalled', () {
     late Directory patchDir;
     File identity() => File('${patchDir.path}/installed_patch_identity.json');
+    // The engine writes patch.vmcode on Android/desktop (host platform in
+    // tests). The skip is gated on these bytes being present.
+    File patchFile() => File('${patchDir.path}/patch.vmcode');
 
     setUp(() => patchDir = Directory.systemTemp.createTempSync('reoffer'));
     tearDown(() => patchDir.deleteSync(recursive: true));
 
-    void writeIdentity({String? id, String? hash}) {
+    void installed({String? id, String? hash}) {
+      patchFile().writeAsBytesSync([1, 2, 3]);
       identity().writeAsStringSync(jsonEncode({
         if (id != null) 'patch_id': id,
         if (hash != null) 'patch_hash': hash,
@@ -27,6 +31,7 @@ void main() {
     }
 
     test('no identity file → not already installed', () {
+      patchFile().writeAsBytesSync([1]);
       expect(
         CodePush.debugIsPatchAlreadyInstalled(
           patchDir: patchDir.path,
@@ -38,7 +43,7 @@ void main() {
     });
 
     test('matches the installed patch by id (would skip re-offer)', () {
-      writeIdentity(id: 'installed');
+      installed(id: 'installed');
       expect(
         CodePush.debugIsPatchAlreadyInstalled(
           patchDir: patchDir.path,
@@ -50,7 +55,7 @@ void main() {
     });
 
     test('a genuinely new patch is not "already installed", file kept', () {
-      writeIdentity(id: 'old', hash: 'oldhash');
+      installed(id: 'old', hash: 'oldhash');
       expect(
         CodePush.debugIsPatchAlreadyInstalled(
           patchDir: patchDir.path,
@@ -64,7 +69,26 @@ void main() {
       expect(identity().existsSync(), isTrue);
     });
 
+    test(
+        'REGRESSION: identity survives but patch bytes were rolled back → '
+        'NOT already installed (re-delivery not blocked)', () {
+      // OTA kill switch / public rollback() removes the patch bytes but
+      // leaves installed_patch_identity.json. A re-offer of the same
+      // patch must proceed, not be skipped forever.
+      installed(id: 'reverted', hash: 'h');
+      patchFile().deleteSync(); // rolled back — bytes gone, identity stale
+      expect(
+        CodePush.debugIsPatchAlreadyInstalled(
+          patchDir: patchDir.path,
+          patchId: 'reverted',
+          patchHash: 'h',
+        ),
+        isFalse,
+      );
+    });
+
     test('corrupt identity does not block a fresh install', () {
+      patchFile().writeAsBytesSync([1]);
       identity().writeAsStringSync('{ nope');
       expect(
         CodePush.debugIsPatchAlreadyInstalled(
@@ -115,7 +139,7 @@ void main() {
 
       expect(first, isNotNull);
       expect(int.tryParse(first!), isNotNull, reason: 'must be numeric');
-      expect(int.parse(first), greaterThan(0));
+      expect(int.parse(first), greaterThanOrEqualTo(0));
       expect(second, equals(first), reason: 'stable across calls');
       expect(File('${patchDir.path}/device_id').existsSync(), isTrue);
     });
@@ -131,6 +155,87 @@ void main() {
       final dh = requests.single.queryParameters['device_hash'];
       expect(dh, isNotNull);
       expect(int.tryParse(dh!), isNotNull);
+    });
+  });
+
+  // ── Finding #6 end-to-end through checkAndInstall ───────────────────
+  group('checkAndInstall already-installed short-circuit', () {
+    late Directory patchDir;
+    late HttpServer server;
+    late int downloads;
+
+    void serveOffer() {
+      server.listen((HttpRequest req) {
+        if (req.uri.path.endsWith('/updates')) {
+          req.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(jsonEncode({
+              'patch_available': true,
+              'patch_id': 'p1',
+              'patch_hash': 'h1',
+              'patch_url': 'http://127.0.0.1:${server.port}/patch',
+            }));
+        } else {
+          downloads++; // the patch download endpoint
+          req.response.statusCode = HttpStatus.notFound;
+        }
+        req.response.close();
+      });
+    }
+
+    setUp(() async {
+      patchDir = Directory.systemTemp.createTempSync('reoffer_e2e');
+      downloads = 0;
+      CodePush.debugResetBaselineHashCache();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(engineChannel, (MethodCall call) async {
+        if (call.method == 'CodePush.getPatchDir') return patchDir.path;
+        if (call.method == 'CodePush.getEngineAbi') return 'abi';
+        return null;
+      });
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    });
+
+    tearDown(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(engineChannel, null);
+      CodePush.debugResetBaselineHashCache();
+      await server.close(force: true);
+      patchDir.deleteSync(recursive: true);
+    });
+
+    Future<bool> check() => CodePush.checkAndInstall(
+          serverUrl: 'http://127.0.0.1:${server.port}',
+          appId: 'app',
+          releaseVersion: '1.0.0+1',
+        );
+
+    test('installed patch re-offered → skipped, no download', () async {
+      // Simulate the patch already installed (bytes + identity).
+      File('${patchDir.path}/patch.vmcode').writeAsBytesSync([1, 2, 3]);
+      File('${patchDir.path}/installed_patch_identity.json').writeAsStringSync(
+          jsonEncode({'patch_id': 'p1', 'patch_hash': 'h1'}));
+      serveOffer();
+
+      final installed = await check();
+
+      expect(installed, isFalse);
+      expect(CodePush.status.value, contains('already installed'));
+      expect(downloads, 0, reason: 'must not re-download the same patch');
+    });
+
+    test(
+        'after rollback (bytes gone, identity stale) → NOT skipped, '
+        'download proceeds', () async {
+      // Identity survives, but the patch bytes were reverted.
+      File('${patchDir.path}/installed_patch_identity.json').writeAsStringSync(
+          jsonEncode({'patch_id': 'p1', 'patch_hash': 'h1'}));
+      serveOffer();
+
+      await check();
+
+      expect(downloads, 1, reason: 're-delivery must not be blocked');
     });
   });
 }


### PR DESCRIPTION
## Finding #6 — don't re-offer an already-installed patch
On Android a patch applies on the **next cold boot**, so once it's installed the server keeps offering the same patch and the SDK re-downloads it and re-fires `onUpdateReady` ("restart to apply") on **every launch**. iOS latches `_moduleLoaded`; Android had no equivalent.

`checkAndInstall` now skips an offer whose `patch_id`/`patch_hash` matches the install-time identity in `installed_patch_identity.json` — the file **finding #7 already writes on Android install**, doing double duty here. It survives the restart, so a match means "already applied". A genuinely new patch (different id/hash) still installs and overwrites the identity, so updates aren't blocked. (Complementary to #7's `rolled_back_patch` skip: one means "already installed", the other "rolled back".)

## Finding #11 — send `device_hash` on /updates
The SDK never sent `device_hash`, so the server's 15-minute per-device rate limiter (keyed `app_id:device_hash`) — and rollout bucketing — never applied. It now sends a **stable, numeric per-install id** persisted to the patch dir (`device_id`). Numeric on purpose: the server both keys the limiter with it and computes `device_hash % 100` for staged rollout. Best-effort — omitted if it can't be read/created, which is exactly today's behavior (server just skips the limiter).

## Tests
6 new (`reoffer_and_devicehash_test.dart`): already-installed match/mismatch/corrupt for #6; stable-numeric-persisted id and the param appearing on the /updates query for #11. 90 total pass, analyze clean.

## Companion
Finding #12 (engine: mkdir the patch dir before writing `launch_status.json`, killing a spurious first-launch error log) is an engine-source fix committed locally; it ships with the next engine rebuild — no SDK/app change needed.

## Device note
#6 device check: after a patch applies, confirm the SDK no longer re-downloads / re-prompts each launch (logcat shows `Patch already installed` instead of a fresh download).