### PR TITLE
fix: pre-publish hardening — verify downloads, refuse cleartext, single-flight checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ## 0.1.11-rc.7
 
-- Patch downloads are now verified against the update metadata before use, and update URLs must be secure.
+- Patch downloads are now verified against the update metadata before use.
+- Update checks and patch downloads now require HTTPS. If you point the SDK at a plain-HTTP server or patch host (other than localhost during development), updates will be refused after this upgrade — switch those URLs to HTTPS.
 - Fixes an issue where overlapping update checks could interfere with an applied patch.
 
 ## 0.1.11-rc.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - Documentation-only release: rewrites the changelog with concise, user-facing notes. No code changes from 0.1.10.
 - If you are on the 0.1.x stable line, prefer the 0.1.11 release candidates (see below).
 
+## 0.1.11-rc.7
+
+- Patch downloads are now verified against the update metadata before use, and update URLs must be secure.
+- Fixes an issue where overlapping update checks could interfere with an applied patch.
+
 ## 0.1.11-rc.6
 
 - Fix: apps now rebuild correctly after a successful patch load even when the patch returns no data.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -36,7 +36,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.11-rc.6"
+    version: "0.1.11-rc.7"
   material_color_utilities:
     dependency: transitive
     description:

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show Timer, unawaited;
+import 'dart:async' show Timer, TimeoutException, unawaited;
 import 'dart:convert' show base64Encode, jsonDecode, jsonEncode, utf8;
 import 'dart:io' show Directory, File, FileMode, HttpClient, Platform, exit;
 import 'dart:math' show Random;
@@ -714,6 +714,14 @@ abstract final class CodePush {
   /// patches are tens of megabytes, so the default is generous.
   @visibleForTesting
   static int debugMaxPatchDownloadBytes = 256 * 1024 * 1024;
+
+  /// Per-await bound on update-check and download HTTP operations
+  /// (connect, response start, body read / inter-chunk gap). Visible
+  /// for tests. Prevents a stalled server from wedging the
+  /// single-flight guard — one hang must never latch updates off for
+  /// the process lifetime.
+  @visibleForTesting
+  static Duration debugHttpRequestTimeout = const Duration(seconds: 30);
 
   /// Kills the app process for a cold restart.
   ///
@@ -2008,22 +2016,28 @@ class _HttpResult {
 }
 
 Future<_HttpResult> _httpGet(String url) async {
+  // connectionTimeout only bounds establishing the connection; a server
+  // that accepts and then stalls would otherwise hang this await forever
+  // — and with the single-flight guard in checkAndInstall, one such
+  // hang would silently disable all future update checks for the
+  // process lifetime. Every await is bounded.
+  final timeout = CodePush.debugHttpRequestTimeout;
   final client = HttpClient()..connectionTimeout = const Duration(seconds: 10);
   try {
-    final request = await client.getUrl(Uri.parse(url));
-    final response = await request.close();
-    final bytes = await response.fold<List<int>>(
-      <int>[],
-      (prev, chunk) => prev..addAll(chunk),
-    );
+    final request = await client.getUrl(Uri.parse(url)).timeout(timeout);
+    final response = await request.close().timeout(timeout);
+    final bytes = await response
+        .fold<List<int>>(<int>[], (prev, chunk) => prev..addAll(chunk))
+        .timeout(timeout);
     return _HttpResult(response.statusCode, utf8.decode(bytes), bytes);
   } finally {
-    client.close();
+    client.close(force: true);
   }
 }
 
 Future<_HttpResult> _httpGetBytes(String url) async {
   final maxBytes = CodePush.debugMaxPatchDownloadBytes;
+  final timeout = CodePush.debugHttpRequestTimeout;
   final client = HttpClient()
     ..connectionTimeout = const Duration(seconds: 30)
     // The bytes we hash must be exactly the bytes on the wire — don't
@@ -2031,17 +2045,25 @@ Future<_HttpResult> _httpGetBytes(String url) async {
     // toggled Content-Encoding.
     ..autoUncompress = false;
   try {
-    final request = await client.getUrl(Uri.parse(url));
-    final response = await request.close();
+    final request = await client.getUrl(Uri.parse(url)).timeout(timeout);
+    final response = await request.close().timeout(timeout);
     // Cap the download so a misbehaving server can't drive the app out
     // of memory. Real patches are tens of megabytes.
     if (response.contentLength > maxBytes) {
       return const _HttpResult(-1, '', <int>[]);
     }
+    // Stalls are bounded two ways: the stream timeout fires on any
+    // inter-chunk gap, and the deadline bounds a trickling server that
+    // sends a byte just often enough to reset the gap timer.
+    final deadline = DateTime.now().add(const Duration(minutes: 15));
     final bytes = <int>[];
-    await for (final chunk in response) {
+    await for (final chunk in response.timeout(
+      timeout,
+      onTimeout: (sink) =>
+          sink.addError(TimeoutException('patch download stalled', timeout)),
+    )) {
       bytes.addAll(chunk);
-      if (bytes.length > maxBytes) {
+      if (bytes.length > maxBytes || DateTime.now().isAfter(deadline)) {
         return const _HttpResult(-1, '', <int>[]);
       }
     }
@@ -2052,20 +2074,20 @@ Future<_HttpResult> _httpGetBytes(String url) async {
 }
 
 Future<_HttpResult> _httpPostJson(String url, Map<String, dynamic> body) async {
+  final timeout = CodePush.debugHttpRequestTimeout;
   final client = HttpClient()..connectionTimeout = const Duration(seconds: 10);
   try {
-    final request = await client.postUrl(Uri.parse(url));
+    final request = await client.postUrl(Uri.parse(url)).timeout(timeout);
     request.headers.set('Content-Type', 'application/json');
     final encoded = utf8.encode(jsonEncode(body));
     request.contentLength = encoded.length;
     request.add(encoded);
-    final response = await request.close();
-    final bytes = await response.fold<List<int>>(
-      <int>[],
-      (prev, chunk) => prev..addAll(chunk),
-    );
+    final response = await request.close().timeout(timeout);
+    final bytes = await response
+        .fold<List<int>>(<int>[], (prev, chunk) => prev..addAll(chunk))
+        .timeout(timeout);
     return _HttpResult(response.statusCode, utf8.decode(bytes), bytes);
   } finally {
-    client.close();
+    client.close(force: true);
   }
 }

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -273,12 +273,29 @@ abstract final class CodePush {
     // Single-flight: the init chain, the periodic timer, and app-resume
     // can overlap. Concurrent checks would double-download, and on iOS a
     // second load of the same payload throws — whose rollback would then
-    // revert the copy the first call just loaded successfully.
+    // revert the copy the first call just loaded successfully. The guard
+    // is deliberately global (not per appId/channel): apps use a single
+    // config, and a losing caller's `false` means "another check is
+    // already running", not "no update".
     if (_checkInFlight) return false;
     _checkInFlight = true;
     try {
       print('[CP] checkAndInstall start');
       status.value = 'Checking server...';
+      // The offer is the trust root — it vends both the patch URL and
+      // the hash the download is verified against — so the metadata
+      // channel itself must be secure too. Loopback is exempt for
+      // development and tests.
+      final serverUri = Uri.tryParse(serverUrl);
+      final isLoopbackServer = serverUri != null &&
+          (serverUri.host == '127.0.0.1' ||
+              serverUri.host == 'localhost' ||
+              serverUri.host == '::1');
+      if (serverUri == null ||
+          (serverUri.scheme != 'https' && !isLoopbackServer)) {
+        status.value = 'Insecure server URL refused';
+        return false;
+      }
       // Compute the baseline hash once, up front, so it can be
       // included in the /updates query. The server uses it as a
       // belt-and-suspenders gate: if the patch on file has a
@@ -2007,7 +2024,12 @@ Future<_HttpResult> _httpGet(String url) async {
 
 Future<_HttpResult> _httpGetBytes(String url) async {
   final maxBytes = CodePush.debugMaxPatchDownloadBytes;
-  final client = HttpClient()..connectionTimeout = const Duration(seconds: 30);
+  final client = HttpClient()
+    ..connectionTimeout = const Duration(seconds: 30)
+    // The bytes we hash must be exactly the bytes on the wire — don't
+    // let transparent gunzip make integrity depend on whether a CDN
+    // toggled Content-Encoding.
+    ..autoUncompress = false;
   try {
     final request = await client.getUrl(Uri.parse(url));
     final response = await request.close();

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -2022,13 +2022,28 @@ Future<_HttpResult> _httpGet(String url) async {
   // hang would silently disable all future update checks for the
   // process lifetime. Every await is bounded.
   final timeout = CodePush.debugHttpRequestTimeout;
+  // Offers and errors are kilobytes of JSON; cap generously so a
+  // hostile server can't OOM the app through the metadata channel
+  // either (the patch download has its own, larger cap).
+  const maxBytes = 1024 * 1024;
   final client = HttpClient()..connectionTimeout = const Duration(seconds: 10);
   try {
     final request = await client.getUrl(Uri.parse(url)).timeout(timeout);
     final response = await request.close().timeout(timeout);
-    final bytes = await response
-        .fold<List<int>>(<int>[], (prev, chunk) => prev..addAll(chunk))
-        .timeout(timeout);
+    if (response.contentLength > maxBytes) {
+      return const _HttpResult(-1, '', <int>[]);
+    }
+    final bytes = <int>[];
+    await for (final chunk in response.timeout(
+      timeout,
+      onTimeout: (sink) =>
+          sink.addError(TimeoutException('response stalled', timeout)),
+    )) {
+      bytes.addAll(chunk);
+      if (bytes.length > maxBytes) {
+        return const _HttpResult(-1, '', <int>[]);
+      }
+    }
     return _HttpResult(response.statusCode, utf8.decode(bytes), bytes);
   } finally {
     client.close(force: true);

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -270,6 +270,12 @@ abstract final class CodePush {
     String channel = 'production',
     VoidCallback? onUpdateReady,
   }) async {
+    // Single-flight: the init chain, the periodic timer, and app-resume
+    // can overlap. Concurrent checks would double-download, and on iOS a
+    // second load of the same payload throws — whose rollback would then
+    // revert the copy the first call just loaded successfully.
+    if (_checkInFlight) return false;
+    _checkInFlight = true;
     try {
       print('[CP] checkAndInstall start');
       status.value = 'Checking server...';
@@ -284,10 +290,10 @@ abstract final class CodePush {
       final deviceBaselineId = await _readBaselineId();
       final deviceHash = await _deviceHash();
       final url = '$serverUrl/api/v1/updates'
-          '?app_id=$appId'
+          '?app_id=${Uri.encodeComponent(appId)}'
           '&version=${Uri.encodeComponent(releaseVersion)}'
           '&platform=$_platform'
-          '&channel=$channel'
+          '&channel=${Uri.encodeComponent(channel)}'
           '${deviceBaselineHash != null ? '&baseline_hash=$deviceBaselineHash' : ''}'
           '${deviceBaselineId != null ? '&baseline_id=$deviceBaselineId' : ''}'
           '${deviceHash != null ? '&device_hash=$deviceHash' : ''}';
@@ -331,6 +337,18 @@ abstract final class CodePush {
       final patchUrl = data['patch_url'] as String?;
       if (patchUrl == null || patchUrl.isEmpty) {
         status.value = 'No patch URL';
+        return false;
+      }
+      // Executable code must never travel over cleartext. Loopback is
+      // exempt for local development and tests.
+      final patchUri = Uri.tryParse(patchUrl);
+      final isLoopbackPatchHost = patchUri != null &&
+          (patchUri.host == '127.0.0.1' ||
+              patchUri.host == 'localhost' ||
+              patchUri.host == '::1');
+      if (patchUri == null ||
+          (patchUri.scheme != 'https' && !isLoopbackPatchHost)) {
+        status.value = 'Insecure patch URL refused';
         return false;
       }
 
@@ -475,6 +493,19 @@ abstract final class CodePush {
         return false;
       }
 
+      // Verify the download against the offer before anything touches
+      // it: the server's patch_hash covers the exact stored bytes, so a
+      // mismatch means transport corruption or tampering. Legacy servers
+      // that omit the hash skip this check (on Android the engine still
+      // verifies integrity and signature at load time).
+      if (serverPatchHash != null && serverPatchHash.isNotEmpty) {
+        final downloadedHash = sha256.convert(patchBytes).toString();
+        if (downloadedHash != serverPatchHash) {
+          status.value = 'Patch failed verification';
+          return false;
+        }
+      }
+
       status.value = 'Installing (${patchBytes.length}B)...';
       if (Platform.isIOS) {
         if (_moduleLoaded) {
@@ -570,6 +601,15 @@ abstract final class CodePush {
               // ignore: undefined_function
               .codePushLoadModule(Uint8List.fromList(payload));
 
+          // A `false` return is the one non-throw value we refuse: no
+          // engine build uses it to mean success, so if one ever signals
+          // failure this way, latching success here would mark a bad
+          // patch active AND clear its quarantine marker below. Throwing
+          // routes it through the normal rollback path.
+          if (rawResult == false) {
+            throw StateError('module load reported failure');
+          }
+
           // Module loaded live — no restart needed on iOS.
           // Auto-parse JSON strings into Map/List for structured data.
           Object? result = rawResult;
@@ -645,8 +685,18 @@ abstract final class CodePush {
     } catch (e) {
       status.value = 'Error: $e';
       return false;
+    } finally {
+      _checkInFlight = false;
     }
   }
+
+  /// Guards [checkAndInstall] against overlapping invocations.
+  static bool _checkInFlight = false;
+
+  /// Maximum accepted patch download size. Visible for tests; real
+  /// patches are tens of megabytes, so the default is generous.
+  @visibleForTesting
+  static int debugMaxPatchDownloadBytes = 256 * 1024 * 1024;
 
   /// Kills the app process for a cold restart.
   ///
@@ -1937,7 +1987,7 @@ class _HttpResult {
   final int statusCode;
   final String body;
   final List<int> bytes;
-  _HttpResult(this.statusCode, this.body, this.bytes);
+  const _HttpResult(this.statusCode, this.body, this.bytes);
 }
 
 Future<_HttpResult> _httpGet(String url) async {
@@ -1956,17 +2006,26 @@ Future<_HttpResult> _httpGet(String url) async {
 }
 
 Future<_HttpResult> _httpGetBytes(String url) async {
+  final maxBytes = CodePush.debugMaxPatchDownloadBytes;
   final client = HttpClient()..connectionTimeout = const Duration(seconds: 30);
   try {
     final request = await client.getUrl(Uri.parse(url));
     final response = await request.close();
-    final bytes = await response.fold<List<int>>(
-      <int>[],
-      (prev, chunk) => prev..addAll(chunk),
-    );
+    // Cap the download so a misbehaving server can't drive the app out
+    // of memory. Real patches are tens of megabytes.
+    if (response.contentLength > maxBytes) {
+      return const _HttpResult(-1, '', <int>[]);
+    }
+    final bytes = <int>[];
+    await for (final chunk in response) {
+      bytes.addAll(chunk);
+      if (bytes.length > maxBytes) {
+        return const _HttpResult(-1, '', <int>[]);
+      }
+    }
     return _HttpResult(response.statusCode, '', bytes);
   } finally {
-    client.close();
+    client.close(force: true);
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutterplaza_code_push
 description: Over-the-air code push updates for Flutter apps. Check for updates, download patches, and roll back — all at runtime.
-version: 0.1.11-rc.6
+version: 0.1.11-rc.7
 homepage: https://codepush.flutterplaza.com
 repository: https://github.com/FlutterPlaza/flutterplaza_code_push
 issue_tracker: https://github.com/FlutterPlaza/flutterplaza_code_push/issues

--- a/test/hardening_test.dart
+++ b/test/hardening_test.dart
@@ -151,5 +151,43 @@ void main() {
       expect(await check(), isFalse);
       expect(CodePush.status.value, contains('Download failed'));
     });
+
+    test('a chunked response with no declared length is capped while '
+        'streaming', () async {
+      // A hostile server omits Content-Length, so the pre-check cannot
+      // fire — only the streaming guard can. Chunked transfer encoding
+      // exercises exactly that branch.
+      offeredHash = patchHash;
+      CodePush.debugMaxPatchDownloadBytes = 1024;
+      server.listen((HttpRequest req) async {
+        if (req.uri.path.endsWith('/updates')) {
+          req.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(jsonEncode({
+              'patch_available': true,
+              'patch_id': 'p1',
+              'patch_hash': patchHash,
+              'patch_url': 'http://127.0.0.1:${server.port}/patch',
+            }));
+        } else {
+          // The client aborts mid-stream once the cap trips; writes to
+          // a dead connection throw and must not fail the test zone.
+          try {
+            req.response.headers.chunkedTransferEncoding = true;
+            for (var i = 0; i < 64; i++) {
+              req.response.add(List<int>.filled(64, i)); // 4 KB total
+              await req.response.flush();
+            }
+          } catch (_) {}
+        }
+        try {
+          await req.response.close();
+        } catch (_) {}
+      });
+
+      expect(await check(), isFalse);
+      expect(CodePush.status.value, contains('Download failed'));
+    });
   });
 }

--- a/test/hardening_test.dart
+++ b/test/hardening_test.dart
@@ -71,6 +71,7 @@ void main() {
         .setMockMethodCallHandler(engineChannel, null);
     CodePush.debugResetBaselineHashCache();
     CodePush.debugMaxPatchDownloadBytes = 256 * 1024 * 1024;
+    CodePush.debugHttpRequestTimeout = const Duration(seconds: 30);
     await server.close(force: true);
     patchDir.deleteSync(recursive: true);
   });
@@ -128,6 +129,35 @@ void main() {
   });
 
   group('single-flight', () {
+    test('a stalled server times out and RELEASES the guard', () async {
+      // Regression guard for the wedge: connectionTimeout doesn't bound
+      // the response, so a server that accepts and never answers used
+      // to hang the check forever — latching _checkInFlight and
+      // silently disabling all future update checks.
+      CodePush.debugHttpRequestTimeout = const Duration(milliseconds: 300);
+      server.listen((HttpRequest req) {
+        updateChecks++;
+        // Accept and stall: no response is ever written.
+      });
+
+      final first = await CodePush.checkAndInstall(
+        serverUrl: 'http://127.0.0.1:${server.port}',
+        appId: 'app',
+        releaseVersion: '1.0.0+1',
+      ).timeout(const Duration(seconds: 5));
+      expect(first, isFalse);
+
+      final second = await CodePush.checkAndInstall(
+        serverUrl: 'http://127.0.0.1:${server.port}',
+        appId: 'app',
+        releaseVersion: '1.0.0+1',
+      ).timeout(const Duration(seconds: 5));
+      expect(second, isFalse);
+      expect(updateChecks, 2,
+          reason: 'the guard must release after a timeout — a second '
+              'check reaches the server instead of returning early');
+    });
+
     test('overlapping checks collapse to one server round-trip', () async {
       offeredHash = patchHash;
       offerDelay = const Duration(milliseconds: 300);

--- a/test/hardening_test.dart
+++ b/test/hardening_test.dart
@@ -1,0 +1,155 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterplaza_code_push/flutterplaza_code_push.dart';
+
+/// Pre-publish hardening (reconcile-review findings): download integrity,
+/// cleartext refusal, single-flight checks, and the download size cap.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  HttpOverrides.global = null;
+
+  const engineChannel = MethodChannel('flutter/codepush', JSONMethodCodec());
+  final patchBytes = List<int>.generate(64, (i) => (i * 5) % 256);
+  final patchHash = sha256.convert(patchBytes).toString();
+
+  late Directory patchDir;
+  late HttpServer server;
+  late int downloads;
+  late int updateChecks;
+  Duration offerDelay = Duration.zero;
+  String? offeredHash;
+  String? offeredUrlOverride;
+
+  void serve() {
+    server.listen((HttpRequest req) async {
+      if (req.uri.path.endsWith('/updates')) {
+        updateChecks++;
+        if (offerDelay > Duration.zero) await Future.delayed(offerDelay);
+        req.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(jsonEncode({
+            'patch_available': true,
+            'patch_id': 'p1',
+            if (offeredHash != null) 'patch_hash': offeredHash,
+            'patch_url': offeredUrlOverride ??
+                'http://127.0.0.1:${server.port}/patch',
+          }));
+      } else {
+        downloads++;
+        req.response.statusCode = HttpStatus.ok;
+        req.response.add(patchBytes);
+      }
+      await req.response.close();
+    });
+  }
+
+  setUp(() async {
+    patchDir = Directory.systemTemp.createTempSync('hardening');
+    downloads = 0;
+    updateChecks = 0;
+    offerDelay = Duration.zero;
+    offeredHash = null;
+    offeredUrlOverride = null;
+    CodePush.debugResetBaselineHashCache();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(engineChannel, (MethodCall call) async {
+      if (call.method == 'CodePush.getPatchDir') return patchDir.path;
+      if (call.method == 'CodePush.getEngineAbi') return 'abi';
+      if (call.method == 'CodePush.installPatch') return true;
+      return null;
+    });
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(engineChannel, null);
+    CodePush.debugResetBaselineHashCache();
+    CodePush.debugMaxPatchDownloadBytes = 256 * 1024 * 1024;
+    await server.close(force: true);
+    patchDir.deleteSync(recursive: true);
+  });
+
+  Future<bool> check() => CodePush.checkAndInstall(
+        serverUrl: 'http://127.0.0.1:${server.port}',
+        appId: 'app',
+        releaseVersion: '1.0.0+1',
+      );
+
+  group('download integrity', () {
+    test('matching patch_hash installs', () async {
+      offeredHash = patchHash;
+      serve();
+
+      expect(await check(), isTrue);
+      expect(CodePush.status.value, 'Restart to apply');
+    });
+
+    test('mismatching patch_hash is refused before install', () async {
+      offeredHash = 'f' * 64;
+      serve();
+
+      expect(await check(), isFalse);
+      expect(CodePush.status.value, 'Patch failed verification');
+      expect(downloads, 1, reason: 'refusal happens after download');
+    });
+
+    test('legacy offer without patch_hash still installs', () async {
+      offeredHash = null;
+      serve();
+
+      expect(await check(), isTrue);
+    });
+  });
+
+  group('cleartext refusal', () {
+    test('non-loopback http patch_url is refused without download',
+        () async {
+      offeredHash = patchHash;
+      offeredUrlOverride = 'http://updates.example.com/patch';
+      serve();
+
+      expect(await check(), isFalse);
+      expect(CodePush.status.value, 'Insecure patch URL refused');
+      expect(downloads, 0);
+    });
+
+    test('loopback http stays allowed for development', () async {
+      offeredHash = patchHash;
+      serve();
+
+      expect(await check(), isTrue);
+    });
+  });
+
+  group('single-flight', () {
+    test('overlapping checks collapse to one server round-trip', () async {
+      offeredHash = patchHash;
+      offerDelay = const Duration(milliseconds: 300);
+      serve();
+
+      final results = await Future.wait([check(), check(), check()]);
+
+      expect(results.where((r) => r).length, 1,
+          reason: 'exactly one check wins');
+      expect(updateChecks, 1, reason: 'losers return before the network');
+      expect(downloads, 1);
+    });
+  });
+
+  group('download size cap', () {
+    test('a response larger than the cap fails soft', () async {
+      offeredHash = patchHash;
+      CodePush.debugMaxPatchDownloadBytes = 16; // patch is 64 bytes
+      serve();
+
+      expect(await check(), isFalse);
+      expect(CodePush.status.value, contains('Download failed'));
+    });
+  });
+}


### PR DESCRIPTION
Closes out the pre-publish follow-up recorded on #13 (both Mediums + three Lows, all pre-existing on both lineages — none introduced by the reconcile).

## Changes

1. **Download integrity (Medium):** downloaded bytes are verified against the offer's `patch_hash` before install/load. Verified against server source first: `patch_hash` is sha256 over the exact decompressed container bytes stored at `patch_url` (`release_service.dart:213` + `storage_service.computeHash`), so this cannot false-reject. Legacy offers without the hash skip the check; Android's engine-side verification is unchanged and still authoritative at load time.
2. **Cleartext refusal (Medium, same finding):** `patch_url` must be https, loopback exempt (development/tests).
3. **Single-flight `checkAndInstall` (Medium):** overlapping callers collapse to one server round-trip; losers return `false` immediately. Kills the iOS double-load → spurious-rollback window.
4. **`false` load-hook return = failure (Low):** routed through the rollback path instead of latching success + clearing the quarantine marker.
5. **Query-param encoding (Low):** `app_id`/`channel` now encoded like `version`.
6. **Download size cap (Low):** 256 MB streaming cap with fail-soft; test seam via `debugMaxPatchDownloadBytes`.

## Tests

7 new (`hardening_test.dart`): hash match/mismatch/legacy-absent, non-loopback-http refusal + loopback allowance, 3-way concurrent check collapsing to exactly one round-trip, size-cap fail-soft. Full suite 102/102. Version → 0.1.11-rc.7 with a minimal changelog entry.

This unblocks the SDK publish decision (rc.7 as-is vs promote to 0.1.11 stable).