### PR TITLE
chore: release 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.11
+
+- Adds Android support: patches download, verify, and apply on the next app restart.
+- Patch downloads are verified before use, and update URLs must use HTTPS (plain-HTTP hosts other than localhost are refused).
+- Adds `disableOnPlayStoreInstalls` for keeping over-the-air updates off on Play Store installs.
+- Devices no longer re-download an already-installed or rolled-back patch.
+
 ## 0.1.10+1
 
 - Documentation-only release: rewrites the changelog with concise, user-facing notes. No code changes from 0.1.10.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -36,7 +36,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.11-rc.7"
+    version: "0.1.11"
   material_color_utilities:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutterplaza_code_push
 description: Over-the-air code push updates for Flutter apps. Check for updates, download patches, and roll back — all at runtime.
-version: 0.1.11-rc.7
+version: 0.1.11
 homepage: https://codepush.flutterplaza.com
 repository: https://github.com/FlutterPlaza/flutterplaza_code_push
 issue_tracker: https://github.com/FlutterPlaza/flutterplaza_code_push/issues


### PR DESCRIPTION
Promotes the hardened, reconciled main to stable per the publish decision.

Version `0.1.11-rc.7` → `0.1.11`; new changelog entry summarizing the release from the user's perspective (Android support, verified downloads + HTTPS requirement with its behavior-change callout, `disableOnPlayStoreInstalls`, no re-downloads). No code changes. Suite 104/104.

pub.dev publish follows the merge.