### PR TITLE
fix(ios): re-check engine ABI and container integrity at cold-start reload

### DIFF
--- a/lib/flutterplaza_code_push.dart
+++ b/lib/flutterplaza_code_push.dart
@@ -27,6 +27,7 @@ export 'src/code_push.dart'
         CodePushConfig,
         CodePushOverlay,
         CodePushPatchBuilder,
-        IosLoadedSessionDecision;
+        IosLoadedSessionDecision,
+        IosReloadGateDecision;
 export 'src/models.dart';
 export 'src/widget_renderer.dart' show CodePushWidgetArea;

--- a/lib/flutterplaza_code_push.dart
+++ b/lib/flutterplaza_code_push.dart
@@ -22,6 +22,11 @@
 library;
 
 export 'src/code_push.dart'
-    show CodePush, CodePushConfig, CodePushOverlay, CodePushPatchBuilder;
+    show
+        CodePush,
+        CodePushConfig,
+        CodePushOverlay,
+        CodePushPatchBuilder,
+        IosLoadedSessionDecision;
 export 'src/models.dart';
 export 'src/widget_renderer.dart' show CodePushWidgetArea;

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -39,6 +39,21 @@ enum IosLoadedSessionDecision {
   persistAndRestart,
 }
 
+/// Outcome of the iOS cold-start reload gate — see
+/// [CodePush.debugDecideReloadGate].
+enum IosReloadGateDecision {
+  /// The on-disk patch may be fed to the runtime.
+  load,
+
+  /// The patch records a different engine ABI than the live probe:
+  /// loading risks a VM abort. Skip, release the strike, keep baseline.
+  skipIncompatibleAbi,
+
+  /// The on-disk bytes don't match the recorded hash: corruption, not a
+  /// bad patch. Delete WITHOUT quarantining so re-download can heal.
+  dropCorrupt,
+}
+
 /// Service for managing over-the-air code push updates.
 ///
 /// Provides both low-level methods (check, install, rollback) and a
@@ -1074,6 +1089,34 @@ abstract final class CodePush {
   /// its bytes (nothing would be written anyway), then malformed
   /// containers are rejected before they can overwrite the working
   /// patch, and only then is persist-silent vs persist-restart chosen.
+  /// Pure decision for whether the on-disk patch may be fed to the
+  /// runtime at cold-start reload. Priority: engine-ABI compatibility
+  /// first (an incompatible patch must not be loaded regardless of its
+  /// integrity), then integrity. Absent, empty, or `'unknown'` metadata
+  /// skips the corresponding check, so pre-`engine_abi` installs and
+  /// older baselines degrade to loading exactly as before.
+  @visibleForTesting
+  static IosReloadGateDecision debugDecideReloadGate({
+    required String? storedAbi,
+    required String? liveAbi,
+    required String? storedHash,
+    required String? actualHash,
+  }) {
+    final sAbi = _nonEmptyOrNull(storedAbi);
+    final sHash = _nonEmptyOrNull(storedHash);
+    if (sAbi != null &&
+        sAbi != 'unknown' &&
+        liveAbi != null &&
+        liveAbi != 'unknown' &&
+        sAbi != liveAbi) {
+      return IosReloadGateDecision.skipIncompatibleAbi;
+    }
+    if (sHash != null && actualHash != null && sHash != actualHash) {
+      return IosReloadGateDecision.dropCorrupt;
+    }
+    return IosReloadGateDecision.load;
+  }
+
   @visibleForTesting
   static IosLoadedSessionDecision debugDecideLoadedSessionOffer({
     required bool offerMatchesDisk,
@@ -1792,45 +1835,44 @@ abstract final class CodePush {
       final info = _readInstalledPatchInfo(patchDir);
       final patchId = info?['patch_id']?.toString();
 
-      // Engine-compatibility re-check: the patch records which engine
-      // ABI it was installed against. If the engine has since changed
-      // (a store update whose staleness the native mtime heuristic
-      // missed), feeding the patch to the new engine risks a VM abort
-      // that no try/catch can route to rollback. Skip the load and
-      // release the strike — the baseline keeps running and the next
-      // check fetches a compatible patch. Either side reporting
-      // 'unknown' (older baselines) skips the comparison.
-      final storedAbi = _nonEmptyOrNull(info?['engine_abi']?.toString());
-      if (storedAbi != null &&
-          storedAbi != 'unknown' &&
-          liveAbi != 'unknown' &&
-          storedAbi != liveAbi) {
-        _iosResetBootCounter(patchDir);
-        status.value = 'Installed patch was built for a different engine '
-            '($storedAbi vs $liveAbi) — waiting for a compatible update';
-        return;
-      }
-
       final container = await patchFile.readAsBytes();
-
-      // Integrity re-verify: the stored hash covers the container bytes
-      // as installed. A mismatch is on-disk corruption, NOT a bad patch
-      // — delete without quarantining (a rolled_back_patch marker would
-      // wrongly block re-downloading the same, good patch) so the next
-      // check re-downloads cleanly.
-      final storedHash = _nonEmptyOrNull(info?['patch_hash']?.toString());
-      if (storedHash != null &&
-          sha256.convert(container).toString() != storedHash) {
-        try {
-          patchFile.deleteSync();
-        } catch (_) {}
-        try {
-          File('$patchDir/patch_info.json').deleteSync();
-        } catch (_) {}
-        _iosResetBootCounter(patchDir);
-        status.value =
-            'Installed patch failed integrity check — will re-download';
-        return;
+      final gate = debugDecideReloadGate(
+        storedAbi: info?['engine_abi']?.toString(),
+        liveAbi: liveAbi,
+        storedHash: info?['patch_hash']?.toString(),
+        actualHash: sha256.convert(container).toString(),
+      );
+      switch (gate) {
+        case IosReloadGateDecision.skipIncompatibleAbi:
+          // The engine changed under the patch (a store update whose
+          // staleness the native mtime heuristic missed). Feeding it to
+          // the new engine risks a VM abort no try/catch can route to
+          // rollback. Baseline keeps running; the next check fetches a
+          // compatible patch.
+          _iosResetBootCounter(patchDir);
+          status.value = 'Installed patch was built for a different '
+              'engine — waiting for a compatible update';
+          return;
+        case IosReloadGateDecision.dropCorrupt:
+          // Corruption, NOT a bad patch — delete without quarantining
+          // (a rolled_back_patch marker would wrongly block
+          // re-downloading the same, good patch). The identity file
+          // goes too so the on-disk records stay consistent.
+          try {
+            patchFile.deleteSync();
+          } catch (_) {}
+          try {
+            File('$patchDir/patch_info.json').deleteSync();
+          } catch (_) {}
+          try {
+            File('$patchDir/installed_patch_identity.json').deleteSync();
+          } catch (_) {}
+          _iosResetBootCounter(patchDir);
+          status.value =
+              'Installed patch failed integrity check — will re-download';
+          return;
+        case IosReloadGateDecision.load:
+          break;
       }
 
       // Re-check after the awaits above: a resume-triggered

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -21,6 +21,24 @@ const MethodChannel _channel = MethodChannel(
 /// Channel for the SDK's own native plugin (reads Info.plist, etc.).
 const MethodChannel _pluginChannel = MethodChannel('flutterplaza_code_push');
 
+/// Outcome of the iOS loaded-session offer decision — see
+/// [CodePush.debugDecideLoadedSessionOffer].
+enum IosLoadedSessionDecision {
+  /// The offer is already persisted on disk: nothing to write.
+  skipAlreadyInstalled,
+
+  /// The container fails the format check: refuse to overwrite the
+  /// working patch.
+  rejectMalformed,
+
+  /// Persist, but the offer IS the running module (the server withdrew
+  /// a pending update): no restart banner, no callback.
+  persistSilently,
+
+  /// Persist a genuinely new patch and surface restart-to-apply.
+  persistAndRestart,
+}
+
 /// Service for managing over-the-air code push updates.
 ///
 /// Provides both low-level methods (check, install, rollback) and a
@@ -603,70 +621,84 @@ abstract final class CodePush {
           // either: a device that reloads v1 at every cold start would
           // then never take v2 (permanent upgrade deadlock). Persist it
           // and ask for a restart, mirroring the Android path.
-          if (debugInstalledIdentityMatches(
-            patchDir: patchDir,
-            patchId: patchId,
-            patchHash: offerHash,
-          )) {
-            // Heal the pre-download skip for installs made by older
-            // SDK versions that never wrote the identity file on iOS.
-            if (patchDir != null) {
-              _recordInstalledIdentity(
-                patchDir: patchDir,
-                patchId: patchId,
-                patchHash: offerHash,
-              );
-            }
-            status.value = 'Patch active';
-            return false;
-          }
-          // Validate BEFORE overwriting: this branch never goes through
-          // _iosLoadPayload's format guard, and it is about to replace
-          // the WORKING patch's bytes on disk. Persisting a malformed
-          // container here would destroy a good patch and strand the
-          // device on baseline at the next cold start.
-          if (debugExtractIosPayload(patchBytes) == null) {
-            status.value =
-                'Patch format is unexpected — keeping the current patch. '
-                'Upgrade flutter_compile to the latest version and '
-                'rebuild the patch.';
-            return false;
-          }
-          // Decided BEFORE the disk writes below overwrite the records:
-          // is the offer the module that is running right now? (The
-          // server may have withdrawn a pending update and reverted to
-          // the running patch — disk must converge, but a restart would
-          // change nothing, so no banner and no callback.)
-          final offerIsRunningModule = _identityMatches(
-            <String, Object?>{
-              'patch_id': _loadedPatchId,
-              'patch_hash': _loadedPatchHash,
-            },
-            patchId,
-            offerHash,
-          );
-          await _installPatchFromDart(patchBytes);
-          if (patchDir != null) {
-            _writeIosPatchInfo(patchDir, patchId, downloadedHash);
-            _recordInstalledIdentity(
+          final decision = debugDecideLoadedSessionOffer(
+            offerMatchesDisk: debugInstalledIdentityMatches(
               patchDir: patchDir,
               patchId: patchId,
               patchHash: offerHash,
-            );
-            // The pending patch gets a fresh three-strike budget: any
-            // strikes accrued so far belong to the OLD patch, and the
-            // next boot runs the new one — charging it for its
-            // predecessor's crashes could quarantine a fix before it
-            // ever runs once.
-            _iosResetBootCounter(patchDir);
+            ),
+            formatValid: debugExtractIosPayload(patchBytes) != null,
+            offerMatchesRunningModule: _identityMatches(
+              <String, Object?>{
+                'patch_id': _loadedPatchId,
+                'patch_hash': _loadedPatchHash,
+              },
+              patchId,
+              offerHash,
+            ),
+          );
+          switch (decision) {
+            case IosLoadedSessionDecision.skipAlreadyInstalled:
+              // Heal the pre-download skip for installs made by older
+              // SDK versions that never wrote the identity file on iOS.
+              if (patchDir != null) {
+                _recordInstalledIdentity(
+                  patchDir: patchDir,
+                  patchId: patchId,
+                  patchHash: offerHash,
+                );
+              }
+              status.value = 'Patch active';
+              return false;
+            case IosLoadedSessionDecision.rejectMalformed:
+              // This branch never goes through _iosLoadPayload's format
+              // guard, and persisting a malformed container would
+              // destroy the WORKING patch's bytes and strand the device
+              // on baseline at the next cold start.
+              status.value =
+                  'Patch format is unexpected — keeping the current patch. '
+                  'Upgrade flutter_compile to the latest version and '
+                  'rebuild the patch.';
+              return false;
+            case IosLoadedSessionDecision.persistSilently:
+            case IosLoadedSessionDecision.persistAndRestart:
+              await _installPatchFromDart(patchBytes);
+              if (patchDir != null) {
+                // patch_info deliberately stores the CONTAINER hash
+                // (downloadedHash) — reload re-verifies the on-disk
+                // bytes against it. offerHash is provably equal
+                // whenever the server sent a hash (checked above);
+                // identity records use it for offer comparisons.
+                _writeIosPatchInfo(
+                  patchDir,
+                  patchId,
+                  downloadedHash,
+                  engineAbi: actualEngineFingerprint,
+                );
+                _recordInstalledIdentity(
+                  patchDir: patchDir,
+                  patchId: patchId,
+                  patchHash: offerHash,
+                );
+                // The pending patch gets a fresh three-strike budget:
+                // any strikes accrued so far belong to the OLD patch,
+                // and the next boot runs the new one — charging it for
+                // its predecessor's crashes could quarantine a fix
+                // before it ever runs once.
+                _iosResetBootCounter(patchDir);
+              }
+              if (decision == IosLoadedSessionDecision.persistSilently) {
+                // The server withdrew a pending update and reverted to
+                // the module that is running right now: disk converged,
+                // a restart would change nothing — no banner, no
+                // callback.
+                status.value = 'Patch active';
+                return false;
+              }
+              status.value = 'Restart to apply';
+              onUpdateReady?.call();
+              return true;
           }
-          if (offerIsRunningModule) {
-            status.value = 'Patch active';
-            return false;
-          }
-          status.value = 'Restart to apply';
-          onUpdateReady?.call();
-          return true;
         }
         await _installPatchFromDart(patchBytes);
 
@@ -674,7 +706,12 @@ abstract final class CodePush {
         // was bad.  Written before module load so it's available even
         // if the load crashes the process.
         if (patchDir != null) {
-          _writeIosPatchInfo(patchDir, patchId, downloadedHash);
+          _writeIosPatchInfo(
+            patchDir,
+            patchId,
+            downloadedHash,
+            engineAbi: actualEngineFingerprint,
+          );
           _recordInstalledIdentity(
             patchDir: patchDir,
             patchId: patchId,
@@ -1007,22 +1044,51 @@ abstract final class CodePush {
   }
 
   /// Persists `patch_info.json` for the just-installed iOS patch: the
-  /// rollback paths read it to record which patch was bad, and the
-  /// upgrade check compares offers against it. Best-effort.
+  /// rollback paths read it to record which patch was bad, the upgrade
+  /// check compares offers against it, and the cold-start reload
+  /// re-verifies the on-disk bytes ([patchHash] is the container hash)
+  /// and the engine compatibility ([engineAbi] is the fingerprint the
+  /// patch was installed against). Best-effort.
   static void _writeIosPatchInfo(
     String patchDir,
     String? patchId,
-    String patchHash,
-  ) {
+    String patchHash, {
+    String? engineAbi,
+  }) {
     try {
       File('$patchDir/patch_info.json').writeAsStringSync(
         jsonEncode(<String, Object?>{
           'patch_id': patchId,
           'patch_hash': patchHash,
+          'engine_abi': engineAbi,
           'installed_at': DateTime.now().toIso8601String(),
         }),
       );
     } catch (_) {}
+  }
+
+  /// Pure decision for an offer that arrives while a module is already
+  /// loaded (iOS). Extracted so the four-way branch the upgrade-deadlock
+  /// fix hinges on is testable off-device. Priority order matters:
+  /// an offer already persisted on disk is skipped without looking at
+  /// its bytes (nothing would be written anyway), then malformed
+  /// containers are rejected before they can overwrite the working
+  /// patch, and only then is persist-silent vs persist-restart chosen.
+  @visibleForTesting
+  static IosLoadedSessionDecision debugDecideLoadedSessionOffer({
+    required bool offerMatchesDisk,
+    required bool formatValid,
+    required bool offerMatchesRunningModule,
+  }) {
+    if (offerMatchesDisk) {
+      return IosLoadedSessionDecision.skipAlreadyInstalled;
+    }
+    if (!formatValid) {
+      return IosLoadedSessionDecision.rejectMalformed;
+    }
+    return offerMatchesRunningModule
+        ? IosLoadedSessionDecision.persistSilently
+        : IosLoadedSessionDecision.persistAndRestart;
   }
 
   /// A stable, numeric per-install identifier for the `device_hash`
@@ -1530,8 +1596,9 @@ abstract final class CodePush {
     // Write-to-tmp then rename: a process kill mid-write must never
     // leave a truncated container at the final path — the next boot
     // would roll back and quarantine whatever patch `patch_info.json`
-    // currently names, which may be the GOOD running patch. The `.tmp`
-    // names are already in every cleanup sibling list.
+    // currently names, which may be the GOOD running patch. An orphaned
+    // `.tmp` is harmless (never loaded) and is reaped opportunistically
+    // by the next install or the native stale-bundle cleanup.
     final tmp = File('$patchDir/$_patchFilename.tmp');
     await tmp.writeAsBytes(patchBytes, flush: true);
     tmp.renameSync('$patchDir/$_patchFilename');
@@ -1614,8 +1681,9 @@ abstract final class CodePush {
         );
       }
       // Invoke the runtime hook exposed by the code-push-capable
-      // engine. Callers guarantee the hook exists (install probes the
-      // fingerprint before downloading; reload probes before reading).
+      // engine. Callers guarantee the hook exists (install MATCHES the
+      // server's fingerprint before downloading; reload verifies the
+      // stored engine ABI against the live probe before reading).
       //
       // Return-value semantics: the hook throws on real load failures
       // (bad format, verification failure, etc.). Any non-throw return
@@ -1715,13 +1783,55 @@ abstract final class CodePush {
       // Without it no load is possible, so release the strike that
       // _runCrashProtection just recorded — three launches on a stock
       // engine must not quarantine a patch that was never attempted.
-      if (await _probeEngineFingerprint() == null) {
+      final liveAbi = await _probeEngineFingerprint();
+      if (liveAbi == null) {
         _iosResetBootCounter(patchDir);
         return;
       }
 
+      final info = _readInstalledPatchInfo(patchDir);
+      final patchId = info?['patch_id']?.toString();
+
+      // Engine-compatibility re-check: the patch records which engine
+      // ABI it was installed against. If the engine has since changed
+      // (a store update whose staleness the native mtime heuristic
+      // missed), feeding the patch to the new engine risks a VM abort
+      // that no try/catch can route to rollback. Skip the load and
+      // release the strike — the baseline keeps running and the next
+      // check fetches a compatible patch. Either side reporting
+      // 'unknown' (older baselines) skips the comparison.
+      final storedAbi = _nonEmptyOrNull(info?['engine_abi']?.toString());
+      if (storedAbi != null &&
+          storedAbi != 'unknown' &&
+          liveAbi != 'unknown' &&
+          storedAbi != liveAbi) {
+        _iosResetBootCounter(patchDir);
+        status.value = 'Installed patch was built for a different engine '
+            '($storedAbi vs $liveAbi) — waiting for a compatible update';
+        return;
+      }
+
       final container = await patchFile.readAsBytes();
-      final patchId = _readInstalledPatchId(patchDir);
+
+      // Integrity re-verify: the stored hash covers the container bytes
+      // as installed. A mismatch is on-disk corruption, NOT a bad patch
+      // — delete without quarantining (a rolled_back_patch marker would
+      // wrongly block re-downloading the same, good patch) so the next
+      // check re-downloads cleanly.
+      final storedHash = _nonEmptyOrNull(info?['patch_hash']?.toString());
+      if (storedHash != null &&
+          sha256.convert(container).toString() != storedHash) {
+        try {
+          patchFile.deleteSync();
+        } catch (_) {}
+        try {
+          File('$patchDir/patch_info.json').deleteSync();
+        } catch (_) {}
+        _iosResetBootCounter(patchDir);
+        status.value =
+            'Installed patch failed integrity check — will re-download';
+        return;
+      }
 
       // Re-check after the awaits above: a resume-triggered
       // checkAndInstall can install and load a patch while the probe /
@@ -1745,14 +1855,12 @@ abstract final class CodePush {
 
   /// Reads the installed patch's server id from `patch_info.json`, or
   /// null when absent/unreadable.
-  static String? _readInstalledPatchId(String patchDir) {
+  static Map<String, dynamic>? _readInstalledPatchInfo(String patchDir) {
     try {
       final f = File('$patchDir/patch_info.json');
       if (!f.existsSync()) return null;
       final decoded = jsonDecode(f.readAsStringSync());
-      if (decoded is Map<String, dynamic>) {
-        return decoded['patch_id']?.toString();
-      }
+      if (decoded is Map<String, dynamic>) return decoded;
     } catch (_) {}
     return null;
   }

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -22,7 +22,9 @@ const MethodChannel _channel = MethodChannel(
 const MethodChannel _pluginChannel = MethodChannel('flutterplaza_code_push');
 
 /// Outcome of the iOS loaded-session offer decision — see
-/// [CodePush.debugDecideLoadedSessionOffer].
+/// [CodePush.debugDecideLoadedSessionOffer]. Only produced by
+/// test-visible methods; not part of the supported runtime API.
+@visibleForTesting
 enum IosLoadedSessionDecision {
   /// The offer is already persisted on disk: nothing to write.
   skipAlreadyInstalled,
@@ -40,7 +42,9 @@ enum IosLoadedSessionDecision {
 }
 
 /// Outcome of the iOS cold-start reload gate — see
-/// [CodePush.debugDecideReloadGate].
+/// [CodePush.debugDecideReloadGate]. Only produced by
+/// test-visible methods; not part of the supported runtime API.
+@visibleForTesting
 enum IosReloadGateDecision {
   /// The on-disk patch may be fed to the runtime.
   load,
@@ -1082,13 +1086,6 @@ abstract final class CodePush {
     } catch (_) {}
   }
 
-  /// Pure decision for an offer that arrives while a module is already
-  /// loaded (iOS). Extracted so the four-way branch the upgrade-deadlock
-  /// fix hinges on is testable off-device. Priority order matters:
-  /// an offer already persisted on disk is skipped without looking at
-  /// its bytes (nothing would be written anyway), then malformed
-  /// containers are rejected before they can overwrite the working
-  /// patch, and only then is persist-silent vs persist-restart chosen.
   /// Pure decision for whether the on-disk patch may be fed to the
   /// runtime at cold-start reload. Priority: engine-ABI compatibility
   /// first (an incompatible patch must not be loaded regardless of its
@@ -1117,6 +1114,13 @@ abstract final class CodePush {
     return IosReloadGateDecision.load;
   }
 
+  /// Pure decision for an offer that arrives while a module is already
+  /// loaded (iOS). Extracted so the four-way branch the upgrade-deadlock
+  /// fix hinges on is testable off-device. Priority order matters:
+  /// an offer already persisted on disk is skipped without looking at
+  /// its bytes (nothing would be written anyway), then malformed
+  /// containers are rejected before they can overwrite the working
+  /// patch, and only then is persist-silent vs persist-restart chosen.
   @visibleForTesting
   static IosLoadedSessionDecision debugDecideLoadedSessionOffer({
     required bool offerMatchesDisk,
@@ -1836,6 +1840,16 @@ abstract final class CodePush {
       final patchId = info?['patch_id']?.toString();
 
       final container = await patchFile.readAsBytes();
+
+      // Re-check BEFORE acting on the gate: a resume-triggered
+      // checkAndInstall can install and load a patch while the probe /
+      // file read were in flight. Without this, the stale `info` read
+      // above could be compared against the freshly-installed container
+      // — a false dropCorrupt verdict that would DELETE the good patch
+      // (and a second load on the load path would throw and quarantine
+      // the wrong patch).
+      if (_moduleLoaded) return;
+
       final gate = debugDecideReloadGate(
         storedAbi: info?['engine_abi']?.toString(),
         liveAbi: liveAbi,
@@ -1875,12 +1889,6 @@ abstract final class CodePush {
           break;
       }
 
-      // Re-check after the awaits above: a resume-triggered
-      // checkAndInstall can install and load a patch while the probe /
-      // file read were in flight; a second load would throw and
-      // quarantine the wrong patch.
-      if (_moduleLoaded) return;
-
       await _iosLoadPayload(
         container: container,
         patchDir: patchDir,
@@ -1895,8 +1903,9 @@ abstract final class CodePush {
     }
   }
 
-  /// Reads the installed patch's server id from `patch_info.json`, or
-  /// null when absent/unreadable.
+  /// Reads the installed patch's metadata map from `patch_info.json`
+  /// (`patch_id`, `patch_hash`, `engine_abi`, `installed_at`), or null
+  /// when absent/unreadable.
   static Map<String, dynamic>? _readInstalledPatchInfo(String patchDir) {
     try {
       final f = File('$patchDir/patch_info.json');

--- a/test/hardening_test.dart
+++ b/test/hardening_test.dart
@@ -36,8 +36,8 @@ void main() {
             'patch_available': true,
             'patch_id': 'p1',
             if (offeredHash != null) 'patch_hash': offeredHash,
-            'patch_url': offeredUrlOverride ??
-                'http://127.0.0.1:${server.port}/patch',
+            'patch_url':
+                offeredUrlOverride ?? 'http://127.0.0.1:${server.port}/patch',
           }));
       } else {
         downloads++;
@@ -109,8 +109,7 @@ void main() {
   });
 
   group('cleartext refusal', () {
-    test('non-loopback http patch_url is refused without download',
-        () async {
+    test('non-loopback http patch_url is refused without download', () async {
       offeredHash = patchHash;
       offeredUrlOverride = 'http://updates.example.com/patch';
       serve();
@@ -182,7 +181,8 @@ void main() {
       expect(CodePush.status.value, contains('Download failed'));
     });
 
-    test('a chunked response with no declared length is capped while '
+    test(
+        'a chunked response with no declared length is capped while '
         'streaming', () async {
       // A hostile server omits Content-Length, so the pre-check cannot
       // fire — only the streaming guard can. Chunked transfer encoding

--- a/test/ios_upgrade_deadlock_test.dart
+++ b/test/ios_upgrade_deadlock_test.dart
@@ -169,4 +169,60 @@ void main() {
       isFalse,
     );
   });
+
+  group('debugDecideLoadedSessionOffer (the four-way branch)', () {
+    test('a disk match is skipped without looking at the bytes', () {
+      expect(
+        CodePush.debugDecideLoadedSessionOffer(
+          offerMatchesDisk: true,
+          formatValid: false,
+          offerMatchesRunningModule: true,
+        ),
+        IosLoadedSessionDecision.skipAlreadyInstalled,
+      );
+    });
+
+    test('malformed containers are rejected before any write', () {
+      expect(
+        CodePush.debugDecideLoadedSessionOffer(
+          offerMatchesDisk: false,
+          formatValid: false,
+          offerMatchesRunningModule: false,
+        ),
+        IosLoadedSessionDecision.rejectMalformed,
+      );
+      // Even when the offer claims to be the running module — bytes
+      // that fail the format check must never reach disk.
+      expect(
+        CodePush.debugDecideLoadedSessionOffer(
+          offerMatchesDisk: false,
+          formatValid: false,
+          offerMatchesRunningModule: true,
+        ),
+        IosLoadedSessionDecision.rejectMalformed,
+      );
+    });
+
+    test('server revert to the running module persists silently', () {
+      expect(
+        CodePush.debugDecideLoadedSessionOffer(
+          offerMatchesDisk: false,
+          formatValid: true,
+          offerMatchesRunningModule: true,
+        ),
+        IosLoadedSessionDecision.persistSilently,
+      );
+    });
+
+    test('a genuinely new patch persists with restart-to-apply', () {
+      expect(
+        CodePush.debugDecideLoadedSessionOffer(
+          offerMatchesDisk: false,
+          formatValid: true,
+          offerMatchesRunningModule: false,
+        ),
+        IosLoadedSessionDecision.persistAndRestart,
+      );
+    });
+  });
 }

--- a/test/ios_upgrade_deadlock_test.dart
+++ b/test/ios_upgrade_deadlock_test.dart
@@ -171,7 +171,10 @@ void main() {
   });
 
   group('debugDecideLoadedSessionOffer (the four-way branch)', () {
-    test('a disk match is skipped without looking at the bytes', () {
+    // Note: this is the HELPER's priority order — a disk match wins
+    // regardless of the other inputs. The call site still evaluates
+    // all three predicates eagerly (they are pure and cannot throw).
+    test('a disk match wins regardless of the other inputs', () {
       expect(
         CodePush.debugDecideLoadedSessionOffer(
           offerMatchesDisk: true,
@@ -222,6 +225,104 @@ void main() {
           offerMatchesRunningModule: false,
         ),
         IosLoadedSessionDecision.persistAndRestart,
+      );
+    });
+  });
+
+  group('debugDecideReloadGate (ABI + integrity)', () {
+    test('legacy install with no metadata loads as before', () {
+      expect(
+        CodePush.debugDecideReloadGate(
+          storedAbi: null,
+          liveAbi: 'flutter-3.41.2',
+          storedHash: null,
+          actualHash: 'h',
+        ),
+        IosReloadGateDecision.load,
+      );
+    });
+
+    test('matching ABI and hash loads', () {
+      expect(
+        CodePush.debugDecideReloadGate(
+          storedAbi: 'flutter-3.41.2',
+          liveAbi: 'flutter-3.41.2',
+          storedHash: 'h1',
+          actualHash: 'h1',
+        ),
+        IosReloadGateDecision.load,
+      );
+    });
+
+    test('ABI mismatch skips the load', () {
+      expect(
+        CodePush.debugDecideReloadGate(
+          storedAbi: 'flutter-3.41.2',
+          liveAbi: 'flutter-3.41.6',
+          storedHash: 'h1',
+          actualHash: 'h1',
+        ),
+        IosReloadGateDecision.skipIncompatibleAbi,
+      );
+    });
+
+    test('unknown on either side skips the ABI comparison', () {
+      expect(
+        CodePush.debugDecideReloadGate(
+          storedAbi: 'unknown',
+          liveAbi: 'flutter-3.41.6',
+          storedHash: 'h1',
+          actualHash: 'h1',
+        ),
+        IosReloadGateDecision.load,
+      );
+      expect(
+        CodePush.debugDecideReloadGate(
+          storedAbi: 'flutter-3.41.2',
+          liveAbi: 'unknown',
+          storedHash: 'h1',
+          actualHash: 'h1',
+        ),
+        IosReloadGateDecision.load,
+      );
+    });
+
+    test('empty-string metadata is treated as absent', () {
+      expect(
+        CodePush.debugDecideReloadGate(
+          storedAbi: '',
+          liveAbi: 'flutter-3.41.6',
+          storedHash: '',
+          actualHash: 'h1',
+        ),
+        IosReloadGateDecision.load,
+      );
+    });
+
+    test('hash mismatch drops the corrupt container', () {
+      expect(
+        CodePush.debugDecideReloadGate(
+          storedAbi: 'flutter-3.41.2',
+          liveAbi: 'flutter-3.41.2',
+          storedHash: 'h1',
+          actualHash: 'h2',
+        ),
+        IosReloadGateDecision.dropCorrupt,
+      );
+    });
+
+    test('ABI incompatibility wins over integrity', () {
+      // An incompatible patch must not be loaded regardless of its
+      // bytes; it also must NOT be dropped as corrupt (it may be a
+      // perfectly good patch for the engine it was built against).
+      expect(
+        CodePush.debugDecideReloadGate(
+          storedAbi: 'flutter-3.41.2',
+          liveAbi: 'flutter-3.41.6',
+          storedHash: 'h1',
+          actualHash: 'h2',
+        ),
+        IosReloadGateDecision.skipIncompatibleAbi,
       );
     });
   });


### PR DESCRIPTION
Final PR of the audit-response batch (follows #17, #18).

## What

The cold-start reload loaded whatever was on disk after only a hook-presence probe. Install now records richer metadata and reload re-checks it:

- **Engine ABI re-check** — `patch_info.json` gains `engine_abi` (the fingerprint the patch was installed against). On mismatch with the live probe, the load is skipped and the strike released: a store update whose staleness the native mtime heuristic missed can no longer feed an incompatible patch to the new engine (a VM abort that no `try/catch` can route to rollback). Either side reporting `unknown` skips the comparison — older baselines degrade gracefully.
- **Integrity re-verify** — reload compares `sha256(on-disk container)` to the stored `patch_hash`. A mismatch is **corruption, not a bad patch**: the file is deleted *without* quarantining (a `rolled_back_patch` marker would wrongly block re-downloading the same, good patch), and the next check re-downloads cleanly.

## Tabled items from #17's review, landed here

- 🟠 The four-way loaded-session decision is extracted into a pure, exported, tested helper (`debugDecideLoadedSessionOffer` + `IosLoadedSessionDecision`) with coverage for all four outcomes and their priority order.
- 🟡 The `.tmp`-reaping comment no longer overstates the cleanup guarantee; the load-path comment no longer claims probe/match parity; the `patch_info`-hash-vs-identity-hash choice is documented at the write site.

## Testing

127/127 green (4 new decision tests). The ABI/integrity re-checks execute on-device only (`Platform.isIOS`); the decision logic is covered off-device.