### PR TITLE
fix(ios): rollback keeps in-memory module state true to the VM — and sticks

### DIFF
--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -176,6 +176,11 @@ abstract final class CodePush {
   static String? _loadedPatchId;
   static String? _loadedPatchHash;
 
+  /// True after a rollback nulled [moduleResult] while the module stayed
+  /// resident: the app shows baseline content although patched code is
+  /// loaded, so a disk re-persist of that patch is NOT restart-neutral.
+  static bool _contentRevertedThisSession = false;
+
   /// Initializes automatic code push update checking with crash protection.
   ///
   /// Call this once in your app's startup. It will:
@@ -428,12 +433,14 @@ abstract final class CodePush {
       if (data['ota_disabled'] == true) {
         status.value = 'OTA disabled by server';
         try {
-          // Unconditional: rollback() knows where each platform keeps
+          // Unconditional: the rollback knows where each platform keeps
           // the patch (engine on Android/desktop, file removal on iOS
           // where the engine channel is disabled and isPatched would
           // always answer false) and throws harmlessly when the device
-          // is already clean.
-          await rollback();
+          // is already clean. quarantine: false — the server stopped
+          // offering, and a later re-enable must be able to resume
+          // service with the SAME patch.
+          await _rollbackInternal(quarantine: false);
           status.value =
               'OTA disabled by server — patch removed (restart to apply)';
         } catch (_) {
@@ -706,7 +713,8 @@ abstract final class CodePush {
                 // before it ever runs once.
                 _iosResetBootCounter(patchDir);
               }
-              if (decision == IosLoadedSessionDecision.persistSilently) {
+              if (decision == IosLoadedSessionDecision.persistSilently &&
+                  !_contentRevertedThisSession) {
                 // The server withdrew a pending update and reverted to
                 // the module that is running right now: disk converged,
                 // a restart would change nothing — no banner, no
@@ -714,6 +722,10 @@ abstract final class CodePush {
                 status.value = 'Patch active';
                 return false;
               }
+              // persistAndRestart — or persistSilently after a rollback
+              // reverted the app-facing content this session: the
+              // module is resident but moduleResult was cleared, so a
+              // restart DOES change what the user sees. Surface it.
               status.value = 'Restart to apply';
               onUpdateReady?.call();
               return true;
@@ -1550,7 +1562,19 @@ abstract final class CodePush {
   /// Rolls back to the previous version by removing the active patch.
   /// Takes effect on next cold restart. On iOS (where the engine updater
   /// is disabled), removes the patch file directly from Dart.
-  static Future<void> rollback() async {
+  ///
+  /// A deliberate rollback also QUARANTINES the removed patch: without
+  /// that, the very next update check would silently re-deliver the
+  /// same patch while the server still offers it, undoing this call
+  /// minutes later. The quarantine clears automatically once the server
+  /// offers a different patch.
+  static Future<void> rollback() => _rollbackInternal(quarantine: true);
+
+  /// [quarantine] is false for the OTA kill switch: there the server
+  /// has stopped offering, and a later re-enable must be able to resume
+  /// service with the SAME patch — a marker would block that until an
+  /// unrelated patch shipped.
+  static Future<void> _rollbackInternal({required bool quarantine}) async {
     // Try engine-side rollback first (works on Android/desktop).
     try {
       final bool? success = await _channel.invokeMethod<bool>(
@@ -1568,13 +1592,52 @@ abstract final class CodePush {
     if (!patchFile.existsSync()) {
       throw CodePushException('No active patch to roll back.');
     }
+    if (quarantine) {
+      // Record the identity BEFORE deleting patch_info below — the
+      // loaded-session running-module match would otherwise re-persist
+      // a patch the caller explicitly removed (see [rollback]).
+      try {
+        final info = _readInstalledPatchInfo(patchDir);
+        if (info != null) {
+          File('$patchDir/rolled_back_patch').writeAsStringSync(
+            jsonEncode(<String, Object?>{
+              'patch_id': info['patch_id'],
+              'patch_hash': info['patch_hash'],
+              'rolled_back_at': DateTime.now().toIso8601String(),
+            }),
+          );
+        }
+      } catch (_) {}
+    }
     patchFile.deleteSync();
     final infoFile = File('$patchDir/patch_info.json');
     if (infoFile.existsSync()) infoFile.deleteSync();
     _iosResetBootCounter(patchDir);
-    _moduleLoaded = false;
-    _loadedPatchId = null;
-    _loadedPatchHash = null;
+    // In-memory state: a loaded module CANNOT be unloaded from the
+    // running VM — the disk is clean, but the module stays resident
+    // until the next cold start (which is exactly what this method's
+    // doc has always promised). _moduleLoaded and the loaded identity
+    // must keep telling that truth: clearing them here would let a
+    // same-session install take the fresh-load path, and a second
+    // loadModule into this VM throws — the failure handler would then
+    // quarantine the NEW patch, losing a healthy update until the
+    // server ships a different one. With the flag intact, a later
+    // offer goes through the persist-don't-load branch (and a
+    // re-offer of the still-resident patch converges silently via the
+    // running-module identity).
+    //
+    // moduleResult IS cleared: it is the app-facing content signal,
+    // and apps keying UI off it should revert immediately — the
+    // kill-switch UX — even though the code stays resident.
+    if (_moduleLoaded) {
+      status.value = 'Patch removed — active until restart';
+      // Remember that the app-facing content was reverted while the
+      // module stays resident: a later "persist silently" convergence
+      // (kill-switch bounce re-offering the resident patch) is NOT
+      // restart-neutral in that state — a restart restores the content
+      // — so the restart banner must fire. Cleared on successful load.
+      _contentRevertedThisSession = true;
+    }
     moduleResult.value = null;
   }
 
@@ -1766,6 +1829,7 @@ abstract final class CodePush {
       _moduleLoaded = true;
       _loadedPatchId = patchId;
       _loadedPatchHash = sha256.convert(container).toString();
+      _contentRevertedThisSession = false;
       moduleResult.value = result;
       status.value = 'Patch active';
       // Clear any previous rollback marker — this patch works.

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -713,8 +713,10 @@ abstract final class CodePush {
                 // before it ever runs once.
                 _iosResetBootCounter(patchDir);
               }
-              if (decision == IosLoadedSessionDecision.persistSilently &&
-                  !_contentRevertedThisSession) {
+              if (!debugPersistOutcomeShowsRestart(
+                decision: decision,
+                contentRevertedThisSession: _contentRevertedThisSession,
+              )) {
                 // The server withdrew a pending update and reverted to
                 // the module that is running right now: disk converged,
                 // a restart would change nothing — no banner, no
@@ -1133,6 +1135,37 @@ abstract final class CodePush {
   /// its bytes (nothing would be written anyway), then malformed
   /// containers are rejected before they can overwrite the working
   /// patch, and only then is persist-silent vs persist-restart chosen.
+  /// Whether a persist outcome must surface the restart banner (and
+  /// fire `onUpdateReady`) rather than converge silently. Silent
+  /// convergence is only honest when the offer IS the running module
+  /// AND its app-facing content signal was not reverted this session
+  /// (a kill-switch bounce clears [moduleResult] while the module stays
+  /// resident — there a restart genuinely restores content).
+  @visibleForTesting
+  static bool debugPersistOutcomeShowsRestart({
+    required IosLoadedSessionDecision decision,
+    required bool contentRevertedThisSession,
+  }) {
+    return decision == IosLoadedSessionDecision.persistAndRestart ||
+        contentRevertedThisSession;
+  }
+
+  /// Test-only window onto the resident-module state, so the
+  /// "rollback keeps in-memory state true to the VM" behavior is
+  /// assertable off-device.
+  @visibleForTesting
+  static bool get debugModuleLoadedForTesting => _moduleLoaded;
+
+  @visibleForTesting
+  static set debugModuleLoadedForTesting(bool value) {
+    _moduleLoaded = value;
+    if (!value) {
+      _loadedPatchId = null;
+      _loadedPatchHash = null;
+      _contentRevertedThisSession = false;
+    }
+  }
+
   @visibleForTesting
   static IosLoadedSessionDecision debugDecideLoadedSessionOffer({
     required bool offerMatchesDisk,
@@ -1563,11 +1596,13 @@ abstract final class CodePush {
   /// Takes effect on next cold restart. On iOS (where the engine updater
   /// is disabled), removes the patch file directly from Dart.
   ///
-  /// A deliberate rollback also QUARANTINES the removed patch: without
-  /// that, the very next update check would silently re-deliver the
-  /// same patch while the server still offers it, undoing this call
-  /// minutes later. The quarantine clears automatically once the server
-  /// offers a different patch.
+  /// A deliberate rollback also QUARANTINES the removed patch (on the
+  /// iOS Dart-side path; Android's engine-side rollback does its own
+  /// bookkeeping via the rollback breadcrumb): without that, the very
+  /// next update check would silently re-deliver the same patch while
+  /// the server still offers it, undoing this call minutes later. The
+  /// quarantine clears automatically once the server offers a
+  /// different patch.
   static Future<void> rollback() => _rollbackInternal(quarantine: true);
 
   /// [quarantine] is false for the OTA kill switch: there the server
@@ -2078,6 +2113,9 @@ abstract final class CodePush {
     _moduleLoaded = false;
     _loadedPatchId = null;
     _loadedPatchHash = null;
+    // Keep the invariant "latch implies resident revert" local: once the
+    // flags say nothing is resident, the latch must not linger either.
+    _contentRevertedThisSession = false;
     moduleResult.value = null;
 
     // 4. Report the failure to the server (fire-and-forget).

--- a/lib/src/code_push.dart
+++ b/lib/src/code_push.dart
@@ -1704,9 +1704,21 @@ abstract final class CodePush {
         }
       } catch (_) {}
     }
-    patchFile.deleteSync();
+    // Delete both the current (patch.bytecode) and legacy (patch.vmcode)
+    // filenames — mirroring the auto-rollback paths — so a device
+    // upgraded from an old SDK can't keep a stale artifact through a
+    // deliberate rollback.
+    for (final name in const ['patch.bytecode', 'patch.vmcode']) {
+      final f = File('$patchDir/$name');
+      if (f.existsSync()) f.deleteSync();
+    }
     final infoFile = File('$patchDir/patch_info.json');
     if (infoFile.existsSync()) infoFile.deleteSync();
+    // installed_patch_identity.json deliberately SURVIVES this delete:
+    // the already-installed skip is gated on the patch FILE existing,
+    // so a surviving identity cannot block re-delivery — and on
+    // Android it is the quarantine-promotion source. If that
+    // file-exists gate ever moves, revisit this reliance.
     _iosResetBootCounter(patchDir);
     // In-memory state: a loaded module CANNOT be unloaded from the
     // running VM — the disk is clean, but the module stays resident

--- a/test/ios_rollback_quarantine_test.dart
+++ b/test/ios_rollback_quarantine_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterplaza_code_push/flutterplaza_code_push.dart';
+
+/// A deliberate [CodePush.rollback] must STICK: it quarantines the
+/// removed patch so the next update check cannot silently re-deliver it
+/// while the server still offers it. (The OTA kill switch goes through
+/// the non-quarantining internal path instead — there the server has
+/// stopped offering, and a re-enable must resume with the same patch.)
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const engineChannel = MethodChannel('flutter/codepush', JSONMethodCodec());
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  // ONE directory for the whole file: CodePush memoizes the patch dir
+  // (_cachedPatchDir), so per-test directories would go stale after the
+  // first lookup. Contents are wiped between tests instead.
+  late Directory tmp;
+
+  setUpAll(() {
+    tmp = Directory.systemTemp.createTempSync('cp_rollback_test');
+  });
+
+  tearDownAll(() {
+    try {
+      tmp.deleteSync(recursive: true);
+    } catch (_) {}
+  });
+
+  setUp(() {
+    for (final e in tmp.listSync()) {
+      try {
+        e.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+    messenger.setMockMethodCallHandler(engineChannel, (MethodCall call) async {
+      switch (call.method) {
+        case 'CodePush.rollback':
+          return false; // Engine updater absent → Dart-side branch runs.
+        case 'CodePush.getPatchDir':
+          return tmp.path;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(engineChannel, null);
+  });
+
+  test('public rollback() quarantines the removed patch', () async {
+    File('${tmp.path}/patch.vmcode').writeAsBytesSync([1, 2, 3, 4]);
+    File('${tmp.path}/patch_info.json').writeAsStringSync(
+      jsonEncode({'patch_id': 'p1', 'patch_hash': 'h1'}),
+    );
+
+    await CodePush.rollback();
+
+    expect(File('${tmp.path}/patch.vmcode').existsSync(), isFalse,
+        reason: 'patch file must be deleted');
+    expect(File('${tmp.path}/patch_info.json').existsSync(), isFalse,
+        reason: 'patch metadata must be deleted');
+
+    final marker = File('${tmp.path}/rolled_back_patch');
+    expect(marker.existsSync(), isTrue,
+        reason: 'a deliberate rollback must quarantine the patch');
+    final rb = jsonDecode(marker.readAsStringSync()) as Map<String, dynamic>;
+    expect(rb['patch_id'], 'p1');
+    expect(rb['patch_hash'], 'h1');
+  });
+
+  test('rollback() without patch metadata still deletes, no marker', () async {
+    File('${tmp.path}/patch.vmcode').writeAsBytesSync([1, 2, 3, 4]);
+
+    await CodePush.rollback();
+
+    expect(File('${tmp.path}/patch.vmcode').existsSync(), isFalse);
+    expect(File('${tmp.path}/rolled_back_patch').existsSync(), isFalse,
+        reason: 'no identity to quarantine — marker must not be written');
+  });
+
+  test('rollback() on a clean device throws and writes nothing', () async {
+    await expectLater(CodePush.rollback(), throwsA(isA<Exception>()));
+    expect(File('${tmp.path}/rolled_back_patch').existsSync(), isFalse);
+  });
+}

--- a/test/ios_rollback_quarantine_test.dart
+++ b/test/ios_rollback_quarantine_test.dart
@@ -88,4 +88,56 @@ void main() {
     await expectLater(CodePush.rollback(), throwsA(isA<Exception>()));
     expect(File('${tmp.path}/rolled_back_patch').existsSync(), isFalse);
   });
+
+  test('rollback() keeps the resident-module flag true to the VM', () async {
+    // A loaded module cannot be unloaded: a disk rollback must NOT
+    // claim the VM is back on baseline, or a same-session install
+    // would double-load and quarantine the wrong patch.
+    File('${tmp.path}/patch.vmcode').writeAsBytesSync([1, 2, 3, 4]);
+    File('${tmp.path}/patch_info.json').writeAsStringSync(
+      jsonEncode({'patch_id': 'p1', 'patch_hash': 'h1'}),
+    );
+    CodePush.debugModuleLoadedForTesting = true;
+    addTearDown(() => CodePush.debugModuleLoadedForTesting = false);
+
+    await CodePush.rollback();
+
+    expect(CodePush.debugModuleLoadedForTesting, isTrue,
+        reason: 'the module stays resident until the next cold start');
+    expect(CodePush.status.value, 'Patch removed — active until restart');
+    expect(CodePush.moduleResult.value, isNull,
+        reason: 'the app-facing content signal reverts immediately');
+  });
+
+  group('debugPersistOutcomeShowsRestart', () {
+    test('silent convergence only when nothing was reverted', () {
+      expect(
+        CodePush.debugPersistOutcomeShowsRestart(
+          decision: IosLoadedSessionDecision.persistSilently,
+          contentRevertedThisSession: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a kill-switch bounce forces the restart banner', () {
+      expect(
+        CodePush.debugPersistOutcomeShowsRestart(
+          decision: IosLoadedSessionDecision.persistSilently,
+          contentRevertedThisSession: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a genuinely new patch always shows the banner', () {
+      expect(
+        CodePush.debugPersistOutcomeShowsRestart(
+          decision: IosLoadedSessionDecision.persistAndRestart,
+          contentRevertedThisSession: false,
+        ),
+        isTrue,
+      );
+    });
+  });
 }

--- a/test/ios_rollback_quarantine_test.dart
+++ b/test/ios_rollback_quarantine_test.dart
@@ -5,6 +5,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutterplaza_code_push/flutterplaza_code_push.dart';
 
+// The kill-switch test drives checkAndInstall against a loopback
+// server; the test binding's stubbed HttpClient must not intercept it.
+
 /// A deliberate [CodePush.rollback] must STICK: it quarantines the
 /// removed patch so the next update check cannot silently re-deliver it
 /// while the server still offers it. (The OTA kill switch goes through
@@ -12,6 +15,7 @@ import 'package:flutterplaza_code_push/flutterplaza_code_push.dart';
 /// stopped offering, and a re-enable must resume with the same patch.)
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  HttpOverrides.global = null;
 
   const engineChannel = MethodChannel('flutter/codepush', JSONMethodCodec());
   final messenger =
@@ -87,6 +91,44 @@ void main() {
   test('rollback() on a clean device throws and writes nothing', () async {
     await expectLater(CodePush.rollback(), throwsA(isA<Exception>()));
     expect(File('${tmp.path}/rolled_back_patch').existsSync(), isFalse);
+  });
+
+  test('kill-switch rollback does NOT quarantine — re-enable can resume',
+      () async {
+    // The opposite contract of the public rollback(): when the SERVER
+    // disables OTA, the patch is removed but no rolled_back_patch
+    // marker may be written — a later re-enable must be able to resume
+    // service with the SAME patch.
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    server.listen((HttpRequest req) {
+      req.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode(<String, dynamic>{
+            'patch_available': false,
+            'ota_disabled': true,
+          }),
+        );
+      req.response.close();
+    });
+
+    File('${tmp.path}/patch.vmcode').writeAsBytesSync([1, 2, 3, 4]);
+    File('${tmp.path}/patch_info.json').writeAsStringSync(
+      jsonEncode({'patch_id': 'p1', 'patch_hash': 'h1'}),
+    );
+
+    await CodePush.checkAndInstall(
+      serverUrl: 'http://127.0.0.1:${server.port}',
+      appId: 'test-app',
+      releaseVersion: '1.0.0+1',
+    );
+
+    expect(File('${tmp.path}/patch.vmcode').existsSync(), isFalse,
+        reason: 'the kill switch must remove the patch');
+    expect(File('${tmp.path}/rolled_back_patch').existsSync(), isFalse,
+        reason: 'the kill-switch rollback must NOT quarantine');
   });
 
   test('rollback() keeps the resident-module flag true to the VM', () async {


### PR DESCRIPTION
Follow-up tabled on #17/#19 (the `rollback()` `_moduleLoaded` lie), approved for this batch.

## The bug

A loaded module cannot be unloaded from the running VM, but the Dart-side rollback (the OTA kill switch's path, and app-called `rollback()`) cleared `_moduleLoaded` and the loaded identity while cleaning the disk — claiming the VM was back on baseline when it wasn't. A same-session install after a rollback then took the fresh-load path; the second `loadModule` into the still-occupied VM threw, and the failure handler **quarantined the NEW patch** — a healthy update lost until the server shipped a different one.

## The fix

The flags now keep telling the truth (`rollback()`'s doc has always promised 'takes effect on next cold restart'): disk cleaned, module stays marked resident, later offers route through the persist-don't-load branch. `moduleResult` still clears as the app-facing kill-switch signal; status reports `Patch removed — active until restart`.

## Hardening from adversarial review of the draft

- **A public `rollback()` must STICK.** Without a marker, the next check silently re-persisted the still-offered patch via the running-module match — undoing the API call minutes later. `rollback()` now quarantines the removed patch (auto-cleared when the server offers a different one). The **kill switch** uses the non-quarantining internal path: there the server stopped offering, and a re-enable must resume service with the SAME patch.
- **Kill-switch bounce honesty.** Re-enable-with-same-patch converges via persist-silently, but `moduleResult` was reverted and can't be restored in-session — 'restart changes nothing' is false there. A `_contentRevertedThisSession` latch routes that case to the `Restart to apply` banner + `onUpdateReady`.

**Known-remaining (pre-existing, tabled):** the in-flight double-load race (a load awaited in one path while another path passes its `_moduleLoaded` check) exists on `main` with identical windows; this branch strictly shrinks load opportunities. Proper fix is a load-serialization gate — its own change.

## Testing

137/137 — 3 new tests for the Dart-side rollback (quarantine written from `patch_info`, no marker without metadata, clean-device throw). The resident-module behavior itself is platform-gated and needs a device cycle.