### PR TITLE
ci: harden the review workflow (draft skip, timeout, concurrency)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,8 +7,13 @@ on:
 jobs:
   claude-review:
     # Repo secrets are not available to PRs from forks; skip them.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Drafts are skipped too — review runs when the PR is ready.
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Lockstep parity with the hardened 2026-08-12 ports (admin/website/patches): draft PRs skipped, 30-minute timeout, per-PR concurrency group with cancel-in-progress. The review bot self-skips on PRs modifying its own workflow (anti-injection guard), so this PR's gate is a local review — the identical hunk was review-approved twice today on the new ports.