### PR TITLE
chore(ci): route top-tier Claude review to claude-opus-5

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,7 +41,7 @@ jobs:
           elif [ "$CHANGED" -le 1200 ] && [ "$SENSITIVE" -eq 0 ]; then
             MODEL=claude-sonnet-5
           else
-            MODEL=claude-opus-4-8
+            MODEL=claude-opus-5
           fi
           echo "model=$MODEL" >> "$GITHUB_OUTPUT"
           echo "changed=$CHANGED sensitive=$SENSITIVE model=$MODEL"


### PR DESCRIPTION
Updates the complexity-routed review model: large or sensitive PRs now use `claude-opus-5` (was `claude-opus-4-8`). Haiku 4.5 / Sonnet 5 tiers unchanged.

Note: the review bot skips PRs that modify its own workflow file (anti-injection guard) — review locally with `/code-review`.